### PR TITLE
QuantumWhile fix to compress controls

### DIFF
--- a/MicrosoftQuantumCrypto/Basics.qs
+++ b/MicrosoftQuantumCrypto/Basics.qs
@@ -1100,8 +1100,17 @@ namespace Microsoft.Quantum.Crypto.Basics {
             Fact(upperBound>lowerBound, $"Upper bound ({upperBound}) must be higher than lower bound ({lowerBound})");
             Fact(upperBound-lowerBound<counter::period, $"Counter's period is {counter::period} but may need to count {upperBound-lowerBound} iterations");
             using (mainControl = Qubit()){
-                for (roundNum in 0..lowerBound - 1){
-                    (Controlled Body)(controls, (roundNum));
+                // Use the main control if there are too many controls
+                if (Length(controls) > 1){
+                    CheckIfAllOnes(controls, mainControl);
+                    for (roundNum in 0..lowerBound - 1){
+                        (Controlled Body)([mainControl], (roundNum));
+                    }
+                    (Adjoint CheckIfAllOnes)(controls, mainControl);
+                } else {
+                    for (roundNum in 0..lowerBound - 1){
+                        (Controlled Body)(controls, (roundNum));
+                    }
                 }
                 for (roundNum in lowerBound..upperBound-1){
                     //Logic here : maincontrol is initially 0


### PR DESCRIPTION
When I ran the tests, they output "Warning: GCD using 2 control qubits". I had put this warning in to notice when the modular inversion had too many controls. I changed the QuantumWhile operation so it will compress the controls before calling the next round, which prevents the issue.