### PR TITLE
Update to Q# v0.24.208024

### DIFF
--- a/MicrosoftQuantumCrypto/Arithmetic.qs
+++ b/MicrosoftQuantumCrypto/Arithmetic.qs
@@ -211,20 +211,20 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     operation SwapLE(xs : LittleEndian, ys : LittleEndian) : Unit {
         body (...){
             Fact(Length(xs!) == Length(ys!), $"Registers must have equal lengths to swap (current lengths : {Length(xs!)} and {Length(ys!)})");
-            for (idx in 0..Length(xs!) - 1){
+            for idx in 0..Length(xs!) - 1 {
                 SWAP(xs![idx], ys![idx]);
             }
         }
         controlled(controls, ...){
             Fact(Length(xs!) == Length(ys!), $"Registers must have equal lengths to swap (current lengths : {Length(xs!)} and {Length(ys!)})");
             if (IsMinimizeWidthCostMetric()) {
-                for (idx in 0 .. Length(xs!) - 1){
+                for idx in 0 .. Length(xs!) - 1 {
                     (Controlled SWAP)(controls, (xs![idx], ys![idx]));
                 }
             } else {
-                using (singleControls = Qubit[Length(xs!)]){
+                use singleControls = Qubit[Length(xs!)] {
                     (Controlled FanoutControls)(controls, (singleControls));
-                    for (idx in 0..Length(xs!) - 1){
+                    for idx in 0..Length(xs!) - 1 {
                         (Controlled SWAP)([singleControls[idx]], (xs![idx], ys![idx]));
                     }
                     (Adjoint Controlled FanoutControls)(controls, (singleControls));
@@ -247,7 +247,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
             Fact(Length(inputs!)==Length(outputs!), 
                 $"Inputs should be the same length; they are {Length(inputs!)} and {Length(outputs!)}"
             );
-            for (idx in 0..Length(inputs!)-1){
+            for idx in 0..Length(inputs!)-1 {
                 CNOT(inputs![idx], outputs![idx]);
             }
         }
@@ -256,13 +256,13 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                 $"Inputs should be the same length; they are {Length(inputs!)} and {Length(outputs!)}"
             );
             if (IsMinimizeWidthCostMetric()) {
-                for (idx in 0 .. Length(inputs!) - 1){
+                for idx in 0 .. Length(inputs!) - 1 {
                     (Controlled X)(controls + [inputs![idx]], (outputs![idx]));
                 }
             } else {
-                using (singleControls = Qubit[Length(inputs!)]){
+                use singleControls = Qubit[Length(inputs!)] {
                     (Controlled FanoutControls)(controls, (singleControls));
-                    for (idx in 0..Length(inputs!) - 1){
+                    for idx in 0..Length(inputs!) - 1 {
                         (Controlled X)([singleControls[idx],inputs![idx]], (outputs![idx]));
                     }
                     (Adjoint Controlled FanoutControls)(controls, (singleControls));
@@ -293,11 +293,11 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
         body (...) {
             let valArray = BigIntAsBoolArray(value);
             if (Length(valArray) > Length(target!)){
-                for (idxVal in Length(target!)..Length(valArray) - 1){
+                for idxVal in Length(target!)..Length(valArray) - 1 {
                     Fact(not valArray[idxVal], $"Cannot XOR {value} into a {Length(target!)}-bit register; the number is too big");
                 }
             }
-            for (idxVal in 0..Length(valArray) - 1){
+            for idxVal in 0..Length(valArray) - 1 {
                 if (valArray[idxVal]){
                     X(target![idxVal]);
                 }
@@ -308,13 +308,13 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
             if (Length(posArray)>0){//if the length is zero, then value=0
                 Fact(posArray[Length(posArray) - 1] < Length(target!), $"Cannot XOR {value} into a {Length(target!)}-bit register; the number is too big");
                 if (IsMinimizeWidthCostMetric()) {
-                    for (idx in 0 .. Length(posArray) - 1) {
+                    for idx in 0 .. Length(posArray) - 1 {
                         (Controlled X)(controls, (target![posArray[idx]]));
                     }
                 } else { // not low depth
-                    using (singleControls = Qubit[Length(posArray)]){
+                    use singleControls = Qubit[Length(posArray)] {
                         (Controlled FanoutControls)(controls, (singleControls));
-                        for (idx in 0..Length(posArray) - 1){
+                        for idx in 0..Length(posArray) - 1 {
                             CNOT(singleControls[idx], target![posArray[idx]]);
                         } 
                         (Adjoint Controlled FanoutControls)(controls, (singleControls));
@@ -335,7 +335,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     /// ## value
     /// BigInt integer
     function PositionsOfOnesInBigInt(value : BigInt) : Int[] {
-        mutable positionArray = new Int[HammingWeightL(value)];
+        mutable positionArray = [0, size = HammingWeightL(value)];
         mutable idxPos=0;
         mutable idxVal = 0;
         mutable internalValue = value;
@@ -370,7 +370,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     operation MeasureBigInteger(target : LittleEndian) : BigInt {
         let targetAsBoolArray= ResultArrayAsBoolArray(MultiM(target!));
         mutable measuredBigInt = 0L;
-        for (idxB in Length(targetAsBoolArray)-1..(-1)..0){
+        for idxB in Length(targetAsBoolArray)-1..(-1)..0 {
             set measuredBigInt=2L * measuredBigInt;
             if (targetAsBoolArray[idxB]){
                 set measuredBigInt = measuredBigInt + 1L;
@@ -402,7 +402,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
         body (...) {
             let nQubits = Length(xs!);
 
-            borrowing (g = Qubit[nQubits]) {
+            borrow g = Qubit[nQubits] {
                 let gs = LittleEndian(g);
 
                 if ( nQubits > 3) {
@@ -451,15 +451,15 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     operation _ComputeCarryCascade (constant : BigInt, xs : LittleEndian, gs : LittleEndian) : Unit
     { 
         body (...) {
-            (Controlled _ComputeCarryCascade) (new Qubit[0], (constant, xs, gs));
+            (Controlled _ComputeCarryCascade) ([], (constant, xs, gs));
         }
         adjoint auto;
         controlled (controls, ...) {
             let nQubits = Length(xs!);
             let constantbittemp = BigIntAsBoolArray(constant);
             let bitextension = MaxI(nQubits-Length(constantbittemp), 1);
-            let constantbits = constantbittemp + new Bool[bitextension];
-            for (idx in (nQubits-1)..(-1)..2) {
+            let constantbits = constantbittemp + [false, size = bitextension];
+            for idx in (nQubits-1)..(-1)..2 {
                 if (constantbits[idx]) {
                     (Controlled CNOT) (controls, (xs![idx], gs![idx-1]));
                     (Controlled X) (controls, (xs![idx]));
@@ -476,7 +476,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                 (Controlled CCNOTWrapper) (controls, (xs![0], xs![1], gs![0]));
             }
 
-            for (idx in 1..(nQubits-2)) {
+            for idx in 1..(nQubits-2) {
                 CCNOTWrapper (gs![idx-1], xs![idx + 1], gs![idx]);
             }
         }
@@ -506,7 +506,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     operation ComputeCarry (constant : BigInt, xs : LittleEndian, carry : Qubit) : Unit
     {
         body (...) {
-            (Controlled ComputeCarry) (new Qubit[0], (constant, xs, carry));
+            (Controlled ComputeCarry) ([], (constant, xs, carry));
         }
         adjoint auto;
         controlled (controls, ...) {
@@ -517,7 +517,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                     (Controlled CNOT) (controls, (xs![0], carry));
                 }
             } else {
-                borrowing (gs = Qubit[nQubits-1]) {
+                borrow gs = Qubit[nQubits-1] {
                     (Controlled CNOT) (controls, (gs[nQubits - 2], carry));
                     _ComputeCarryCascade(constant, xs, LittleEndian(gs));
                     (Controlled CNOT) (controls, (gs[nQubits - 2], carry));
@@ -551,7 +551,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     operation _CarryAndDivide (constant : BigInt, xs : LittleEndian) : Unit
     {
         body (...) {
-            (Controlled _CarryAndDivide) (new Qubit[0], (constant, xs));
+            (Controlled _CarryAndDivide) ([], (constant, xs));
         }
         adjoint auto;
         controlled (controls, ...) {
@@ -565,7 +565,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                 let constantLower = constant % 2L ^ lengthLower;
                 let constantHigher = constant / 2L ^ lengthLower;
 
-                borrowing (gs = Qubit[1]) {
+                borrow gs = Qubit[1] {
                     Increment(LittleEndian([gs[0]] + xsHigher!));
                     X(gs[0]);
 
@@ -634,11 +634,11 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     /// Qubit register encoding the integer x.
     operation _AddConstantLowT(constant : BigInt, xs : LittleEndian) : Unit {
         body (...) {
-            (Controlled _AddConstantLowT)(new Qubit[0], (constant, xs));
+            (Controlled _AddConstantLowT)([], (constant, xs));
         }
         controlled (controls, ...){
             let nQubits = Length(xs!);
-            using (constantQubits = Qubit[nQubits]){
+            use constantQubits = Qubit[nQubits] {
                 let constants = LittleEndian(constantQubits);
                 (Controlled ApplyXorInPlaceL)(controls, (constant, constants));
                 AddIntegerNoCarry(constants, xs);
@@ -719,7 +719,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     ///    https://arxiv.org/pdf/1709.06648.pdf
     operation CDKMGAdderNoCarry (xs : LittleEndian, ys : LittleEndian) : Unit {
         body (...){
-            _CDKMGAdderInner(false, xs, ys, new Qubit[0]);
+            _CDKMGAdderInner(false, xs, ys, []);
         }
         controlled adjoint auto;
     }
@@ -754,15 +754,15 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     ///    https://arxiv.org/pdf/1709.06648.pdf
     operation CDKMGAddConstant (constant : BigInt, xs : LittleEndian) : Unit {
         body (...){
-            (Controlled CDKMGAddConstant)(new Qubit[0], (constant, xs));
+            (Controlled CDKMGAddConstant)([], (constant, xs));
         }
         controlled (controls, ...){
             let nQubits = Length(xs!);
             Fact(nQubits>=BitSizeL(constant), $"{constant} is too big to add to a {nQubits} - qubit register");
-            using (constantQubits = Qubit[nQubits]){
+            use constantQubits = Qubit[nQubits] {
                 let constants = LittleEndian(constantQubits);
                 (Controlled ApplyXorInPlaceL)(controls, (constant, constants));
-                _CDKMGAdderInner(false, constants, xs, new Qubit[0]);
+                _CDKMGAdderInner(false, constants, xs, []);
                 (Controlled Adjoint ApplyXorInPlaceL)(controls, (constant, constants));
             }
         }
@@ -798,7 +798,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     ///    https://arxiv.org/pdf/1709.06648.pdf
     operation _CDKMGBlockForward (previousCarry : Qubit, xQubit : Qubit, yQubit : Qubit, nextCarry : Qubit) : Unit {
         body (...){
-            (Controlled _CDKMGBlockForward)(new Qubit[0], (previousCarry, xQubit, yQubit, nextCarry));
+            (Controlled _CDKMGBlockForward)([], (previousCarry, xQubit, yQubit, nextCarry));
         }
         controlled (controls, ...){
             CNOT(previousCarry, xQubit);
@@ -839,7 +839,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     ///    https://arxiv.org/pdf/1709.06648.pdf
     operation _CDKMGBlockBackward (previousCarry : Qubit, xQubit : Qubit, yQubit : Qubit, nextCarry : Qubit) : Unit {
         body (...){
-            (Controlled _CDKMGBlockBackward)(new Qubit[0], (previousCarry, xQubit, yQubit, nextCarry));
+            (Controlled _CDKMGBlockBackward)([], (previousCarry, xQubit, yQubit, nextCarry));
         }
         controlled (controls, ...){
             CNOT(previousCarry, nextCarry);
@@ -874,7 +874,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     ///    https://arxiv.org/pdf/1709.06648.pdf
     operation _CDKMGAdderInner(useCarry : Bool, xs : LittleEndian, ys : LittleEndian, carry : Qubit[]) : Unit {
         body (...) {
-            (Controlled _CDKMGAdderInner)(new Qubit[0], (useCarry, xs, ys, carry));
+            (Controlled _CDKMGAdderInner)([], (useCarry, xs, ys, carry));
         }
         controlled (controls, ...) {
             if (useCarry){
@@ -892,15 +892,15 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                 }
             }
             else {
-                using (carries = Qubit[nQubits]){
+                use carries = Qubit[nQubits] {
                     AndWrapper(xs![0], ys![0], carries[0]);
-                    for (idx in 1..nQubits - 1){
+                    for idx in 1..nQubits - 1 {
                         (Controlled _CDKMGBlockForward)(controls, (carries[idx - 1], xs![idx], ys![idx], carries[idx]));
                     }
                     if (useCarry){
                         (Controlled CNOT)(controls, (carries[nQubits - 1], carry[0]));
                     }
-                    for (idx in (nQubits - 1)..(-1)..1){
+                    for idx in (nQubits - 1)..(-1)..1 {
                         (Controlled _CDKMGBlockBackward)(controls, (carries[idx - 1], xs![idx], ys![idx], carries[idx]));
                     }
                     (Adjoint AndWrapper)(xs![0], ys![0], carries[0]);
@@ -955,11 +955,11 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
         carry : Qubit 
     ) : Unit {
         body (...) {
-            (Controlled CompareToConstant)(new Qubit[0], (isGreaterThan, Comparator, constant, xs, carry));
+            (Controlled CompareToConstant)([], (isGreaterThan, Comparator, constant, xs, carry));
         }
         controlled (controls, ...){
             let nQubits = Length(xs!);
-            using (constantQubits = Qubit[nQubits]){
+            use constantQubits = Qubit[nQubits] {
                 let constants = LittleEndian(constantQubits);
                 if (isGreaterThan){
                     ApplyToEachWrapperCA(X, constantQubits);
@@ -1003,7 +1003,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     ///    https://arxiv.org/pdf/1709.06648.pdf
     operation _CDKMGCompareInner (xs : LittleEndian, ys : LittleEndian, carry : Qubit) : Unit {
     body (...) {
-            (Controlled _CDKMGCompareInner)(new Qubit[0], (xs, ys, carry));
+            (Controlled _CDKMGCompareInner)([], (xs, ys, carry));
         }
         controlled (controls, ...) {
             let nQubits = Length(xs!);
@@ -1013,13 +1013,13 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                 X(ys![0]);
             } else {
                 ApplyToEachCA(X, ys!);
-                using (carries = Qubit[nQubits]){
+                use carries = Qubit[nQubits] {
                     AndWrapper(xs![0], ys![0], carries[0]);
-                    for (idx in 1..nQubits - 1){
+                    for idx in 1..nQubits - 1 {
                         _CDKMGBlockForward (carries[idx - 1], xs![idx], ys![idx], carries[idx]);
                     }
                     (Controlled CNOT)(controls, (carries[nQubits - 1], carry));
-                    for (idx in (nQubits - 1)..(-1)..1){
+                    for idx in (nQubits - 1)..(-1)..1 {
                         (Adjoint _CDKMGBlockForward)(carries[idx - 1], xs![idx], ys![idx], carries[idx]);
                     }
                     (Adjoint AndWrapper)(xs![0], ys![0], carries[0]);
@@ -1073,8 +1073,8 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
             //Odd bit-lengths are much less expensive so we add an extra qubit
             // and do everything as an even bit-length addition
             if (Length(xs!) % 2 == 0){
-                using (bonusQubits = Qubit[1]){
-                    _CLAAdderImpl(CNOT, CCNOTWrapper, AndWrapper, false, xs! + [bonusQubits[0]], ys! + [carry], new Qubit[0]);
+                use bonusQubits = Qubit[1] {
+                    _CLAAdderImpl(CNOT, CCNOTWrapper, AndWrapper, false, xs! + [bonusQubits[0]], ys! + [carry], []);
                 }
             } else {
                 _CLAAdderImpl(CNOT, CCNOTWrapper, AndWrapper, true, xs!, ys!,  [carry]);
@@ -1118,7 +1118,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     ///    https : //arxiv.org/abs/quant - ph/0406142
     operation CarryLookAheadAdderNoCarry(xs : LittleEndian, ys : LittleEndian) : Unit {
         body(...){
-            _CLAAdderImpl(CNOT, CCNOTWrapper, AndWrapper, false, xs!, ys!, new Qubit[0]);
+            _CLAAdderImpl(CNOT, CCNOTWrapper, AndWrapper, false, xs!, ys!, []);
         }
         controlled adjoint auto;
     }
@@ -1142,7 +1142,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
         body(...){
             let nQubits = Length(xs!);
             Fact(nQubits>=BitSizeL(constant), $"{constant} is too big to add to a {nQubits} - qubit register");
-            let constantArray = BigIntAsBoolArray(constant) + new Bool[nQubits - BitSizeL(constant)];
+            let constantArray = BigIntAsBoolArray(constant) + [false, size = nQubits - BitSizeL(constant)];
             _CLAAdderImpl(
                 ClassicalCNOT, 
                 ClassicalCCNOT, 
@@ -1150,7 +1150,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                 false, 
                 constantArray[0.. nQubits - 1], 
                 xs!, 
-                new Qubit[0]
+                []
             );
         }
         controlled adjoint auto;
@@ -1200,7 +1200,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
         carry : Qubit[]
     ) : Unit {
         body(...){
-            (Controlled _CLAAdderImpl)(new Qubit[0], (cqCNOT,cqCCNOTWrapper, cqAND, useCarry, xs, ys, carry));
+            (Controlled _CLAAdderImpl)([], (cqCNOT,cqCCNOTWrapper, cqAND, useCarry, xs, ys, carry));
         }
         controlled(controls, ...){
             //Control logic : The circuit can be split into 5 steps : 
@@ -1236,14 +1236,14 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
             } else {
                 let logn = Floor(Lg(IntAsDouble(nQubits)));
                 let ancillaSize = 2 * nQubits - HammingWeightI(nQubits) - logn;
-                using (ancillaQubits = Qubit[ancillaSize]){
+                use ancillaQubits = Qubit[ancillaSize] {
                     let gens = ancillaQubits[0..nQubits - 2] + carry;
                     let propArrays = PropArrays(ancillaQubits[nQubits - 1..ancillaSize - 1], ys);
                     // 1) Compute initial carries
                 
                     cqAND(xs[0], ys[0], gens[0]);
                     (Controlled cqCNOT)(controls, (xs[0], ys[0]));//will not be uncomputed
-                    for (idx in 1..nQubits - 2){
+                    for idx in 1..nQubits - 2 {
                         cqAND(xs[idx], ys[idx], gens[idx]);
                         cqCNOT(xs[idx], ys[idx]);
                     }
@@ -1268,11 +1268,11 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                     // If it's controlled, it needs to fanout
                     /// into ancilla to keep the depth low
                     if (Length(controls)>0){
-                        using (singleControls = Qubit[nQubits - 1]){
+                        use singleControls = Qubit[nQubits - 1] {
                             (Controlled FanoutControls)(controls, (singleControls));
                             CNOT(singleControls[0], ys[0]);
                             CCNOTWrapper(singleControls[0], gens[0], ys[1]);
-                            for (ids in 1..nQubits - 2){
+                            for ids in 1..nQubits - 2 {
                                 CCNOTWrapper(singleControls[ids], gens[ids], ys[ids + 1]);
                                 CNOT(singleControls[ids], ys[ids]);
                                 cqCCNOTWrapper(xs[ids], singleControls[ids], ys[ids]);
@@ -1282,7 +1282,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                     } else {//without controls
                         X(ys[0]);
                         CNOT(gens[0], ys[1]);
-                        for (ids in 1..nQubits - 2){
+                        for ids in 1..nQubits - 2 {
                             CNOT(gens[ids], ys[ids + 1]);
                             X(ys[ids]);
                             cqCNOT(xs[ids], ys[ids]);
@@ -1297,7 +1297,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
 
                     // 5) Uncompute initial carries
                     (Adjoint cqAND)(xs[0], ys[0], gens[0]);
-                    for (ids in 1..nQubits - 2){
+                    for ids in 1..nQubits - 2 {
                         cqCNOT(xs[ids], ys[ids]);
                         (Adjoint cqAND)(xs[ids], ys[ids], gens[ids]);
                     }
@@ -1341,11 +1341,11 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     /// but simply alters the addition circuit to only output the carry.
     operation GreaterThanLookAhead(xs : LittleEndian, ys : LittleEndian, carry : Qubit) : Unit {
         body (...){
-            (Controlled GreaterThanLookAhead)(new Qubit[0], (xs, ys, carry));
+            (Controlled GreaterThanLookAhead)([], (xs, ys, carry));
         }
         controlled (controls, ...){
             if (Length(xs!) % 2 == 0){
-                using (bonusQubits = Qubit[2]){		
+                use bonusQubits = Qubit[2] {		
                     (Controlled GreaterThanLookAhead)(controls, (
                         LittleEndian(xs! + [bonusQubits[0]]),
                         LittleEndian(ys! + [bonusQubits[1]]),
@@ -1407,7 +1407,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                 // must be greater, so we do not clip the carry
             } else {
                 let constantComplement = constant ^^^ 2L^nQubits - 1L;
-                let constantArray = BigIntAsBoolArray(constantComplement) + new Bool[nQubits - BitSizeL(constantComplement)];
+                let constantArray = BigIntAsBoolArray(constantComplement) + [false, size = nQubits - BitSizeL(constantComplement)];
                 _CompareLookAheadImpl(
                     ClassicalCNOT,
                     ClassicalCCNOT,
@@ -1449,7 +1449,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     /// but simply alters the addition circuit to only output the carry.
     operation LessThanConstantLookAhead(constant : BigInt, xs : LittleEndian, carry : Qubit) : Unit{
         body (...){
-            (Controlled LessThanConstantLookAhead)(new Qubit[0], (constant, xs, carry));
+            (Controlled LessThanConstantLookAhead)([], (constant, xs, carry));
         }
         controlled (controls, ...) {
             let nQubits = Length(xs!);
@@ -1458,7 +1458,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                 // must be greater, so we fip the carry without any work
                 (Controlled X)(controls, (carry));
             } else {
-                let constantArray = BigIntAsBoolArray(constant) + new Bool[nQubits - BitSizeL(constant)];
+                let constantArray = BigIntAsBoolArray(constant) + [false, size = nQubits - BitSizeL(constant)];
                 ApplyToEachWrapperCA(X, xs!);
                 (Controlled _CompareLookAheadImpl)(controls,  (
                     ClassicalCNOT,
@@ -1517,7 +1517,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
         carry : Qubit
     ) : Unit {
         body(...){
-            (Controlled _CompareLookAheadImpl)(new Qubit[0], (
+            (Controlled _CompareLookAheadImpl)([], (
                 cqCNOT,
                 cqCCNOTWrapper,
                 cqAND,
@@ -1534,13 +1534,13 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
                 let logn = Floor(Lg(IntAsDouble(nQubits)));
                 let ancillaSize = 2 * nQubits - Floor(Lg(IntAsDouble(nQubits - 1))) - 3;
 
-                using (ancillaQubits = Qubit[ancillaSize]){
+                use ancillaQubits = Qubit[ancillaSize] {
                     let gens = ancillaQubits[0..nQubits - 2] + [carry];
                     let propArrays = PropArrays(ancillaQubits[nQubits - 1..ancillaSize - 1], ys);
                 
 
                     // 1) Compute initial carries
-                    for (idx in 0..nQubits - 2){
+                    for idx in 0..nQubits - 2 {
                         cqAND(xs[idx], ys[idx], gens[idx]);
                         cqCNOT(xs[idx], ys[idx]);			
                     }
@@ -1557,7 +1557,7 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
 
                      
                     // 5) Uncompute initial carries
-                    for (ids in 0..nQubits - 2){	
+                    for ids in 0..nQubits - 2 {	
                         cqCNOT(xs[ids], ys[ids]);
                         (Adjoint cqAND)(xs[ids], ys[ids], gens[ids]);
                     }
@@ -1600,13 +1600,14 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     function PropArrays(props : Qubit[], ys : Qubit[]) : Qubit[][] {
         let nQubits = Length(ys);
         let logn = Floor(Lg(IntAsDouble(nQubits)));
-        mutable propArrays = new Qubit[][logn];
+        // Here props is a placeholder value to indicate type
+        mutable propArrays = [props, size = logn];
         mutable idxProps=0;
         set propArrays w/= 0 <- ys;
-        for (level in 1..logn - 1){
+        for level in 1..logn - 1 {
             let levelSize = nQubits/2^level - 1;
-            mutable levelProps = new Qubit[levelSize + 1];
-            for (idm in 1..levelSize){
+            mutable levelProps = [props[0], size = levelSize + 1];
+            for idm in 1..levelSize {
                 set levelProps w/= idm <- props[idxProps];
                 set idxProps = idxProps + 1;
             }
@@ -1638,8 +1639,8 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     operation _LookAheadAndComputePropagateCarries(nQubits : Int, propArrays : Qubit[][]) : Unit {
         body (...){
             let logn = Floor(Lg(IntAsDouble(nQubits)));
-            for (idxRound in 1..logn-1){
-                for (idxProps in 1..nQubits / (2 ^ idxRound) - 1){
+            for idxRound in 1..logn-1 {
+                for idxProps in 1..nQubits / (2 ^ idxRound) - 1 {
                         AndWrapper(propArrays[idxRound - 1][2 * idxProps], propArrays[idxRound - 1][2 * idxProps + 1], propArrays[idxRound][idxProps]);
                 }
             }
@@ -1655,9 +1656,9 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
         //indices are high enough to need the controls.
             let logn = Floor(Lg(IntAsDouble(nQubits)));
             // P rounds
-            for (idxRound in 1..logn - 1){
+            for idxRound in 1..logn - 1 {
                 let lognMin1 = Floor(Lg(IntAsDouble(nQubits - 1)));
-                for (idxProps in 1..nQubits / (2 ^ idxRound) - 1){
+                for idxProps in 1..nQubits / (2 ^ idxRound) - 1 {
                     if (idxRound > lognMin1 - 1 or idxProps > (nQubits - 1) / (2 ^ idxRound) - 1){
                         (Controlled X)(controls + propArrays[idxRound-1][2 * idxProps..2 * idxProps + 1], (propArrays[idxRound][idxProps]));
                     } else {
@@ -1694,8 +1695,8 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     operation _LookAheadAndComputeGenerateCarries(nQubits : Int, propArrays : Qubit[][], gens : Qubit[]) : Unit {
         body (...){
             let logn = Floor(Lg(IntAsDouble(nQubits)));
-            for (idxRound in 1..logn){
-                for (idxGens in 0..(nQubits / 2 ^ idxRound) - 1){
+            for idxRound in 1..logn {
+                for idxGens in 0..(nQubits / 2 ^ idxRound) - 1 {
                     CCNOTWrapper(propArrays[idxRound - 1][2 * idxGens + 1], 
                         gens[idxGens * 2 ^ idxRound + 2 ^ (idxRound - 1) - 1],
                         gens[(idxGens + 1) * 2 ^ idxRound - 1]
@@ -1713,9 +1714,9 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
             //Hence, each of the "rounds" must check whether the
             //indices are high enough to need the controls.
             let logn = Floor(Lg(IntAsDouble(nQubits)));
-            for (idxRound in 1..logn){
+            for idxRound in 1..logn {
                 let lognmin1 = Floor(Lg(IntAsDouble(nQubits - 1)));
-                for (idxGens in 0..(nQubits / 2 ^ idxRound) - 1){
+                for idxGens in 0..(nQubits / 2 ^ idxRound) - 1 {
                     if (idxRound > lognmin1 or idxGens > (nQubits - 1)/(2 ^ idxRound) - 1){
                         (Controlled X)(controls + [propArrays[idxRound - 1][2 * idxGens + 1],
                             gens[idxGens * (2 ^ idxRound) + 2 ^ (idxRound - 1) - 1]], 
@@ -1757,8 +1758,8 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
     operation _LookAheadTurnCarriesIntoSum(nQubits : Int, propArrays : Qubit[][], gens : Qubit[]) : Unit {
         body (...){
             let log2nover3 = Floor(Lg(2.0 * IntAsDouble(nQubits) / 3.0));
-            for (idxRound in log2nover3..(-1)..1){
-                for (idxSum in 1.. (nQubits - 2 ^ (idxRound - 1)) / 2 ^ idxRound){
+            for idxRound in log2nover3..(-1)..1 {
+                for idxSum in 1.. (nQubits - 2 ^ (idxRound - 1)) / 2 ^ idxRound {
                         CCNOTWrapper(gens[idxSum * (2 ^ idxRound) - 1], 
                             propArrays[idxRound - 1][2 * idxSum],
                             gens[idxSum * (2 ^ idxRound) + 2 ^ (idxRound - 1) - 1]
@@ -1776,9 +1777,9 @@ namespace Microsoft.Quantum.Crypto.Arithmetic {
             //Hence, each of the "rounds" must check whether the
             //indices are high enough to need the controls.
             let log2nover3 = Floor(Lg(2.0 * IntAsDouble(nQubits) / 3.0));	
-            for (idxRound in log2nover3..( - 1)..1){
+            for idxRound in log2nover3..( - 1)..1 {
                 let log2nmin1over3 = Floor(Lg(2.0 * IntAsDouble(nQubits - 1) / 3.0));
-                for (idc in 1.. (nQubits - 2 ^ (idxRound - 1)) / 2 ^ idxRound){
+                for idc in 1.. (nQubits - 2 ^ (idxRound - 1)) / 2 ^ idxRound {
                     if (idxRound > log2nmin1over3 or idc > (nQubits - 1 - 2 ^ (idxRound - 1)) / 2 ^ idxRound){
                         (Controlled X)(controls + 
                             [gens[idc * 2 ^ idxRound - 1], propArrays[idxRound - 1][2 * idc]],

--- a/MicrosoftQuantumCrypto/Basics.qs
+++ b/MicrosoftQuantumCrypto/Basics.qs
@@ -94,7 +94,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
     // /// - For the circuit diagram see Figure 1 on
     // ///   [ Page 3 of arXiv:1210.0974v2 ](https://arxiv.org/pdf/1210.0974v2.pdf#page=2)
     operation ccnot_T_depth_1 (control1 : Qubit, control2 : Qubit, target : Qubit) : Unit is Adj + Ctl {
-        using (auxillaryRegister = Qubit[4]) {
+        use auxillaryRegister = Qubit[4] {
 
             // apply UVU† where U is outer circuit and V is inner circuit
             ApplyWithCA(TDepthOneCCNOTOuterCircuit, TDepthOneCCNOTInnerCircuit, auxillaryRegister + [target, control1, control2]);
@@ -214,7 +214,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
     /// Craig Gidney. 2019. "Windowed Quantum Arithmetic", https://arxiv.org/abs/1905.07682
     operation EqualLookup<'T> (table: 'T[], QuantumWrite : (('T) => Unit is Ctl + Adj), address: LittleEndian) : Unit {
         body (...) {
-            Controlled EqualLookup(new Qubit[0], (table, QuantumWrite, address));
+            Controlled EqualLookup([], (table, QuantumWrite, address));
         }
         controlled (cs, ...) {
             if (Length(table) == 0) {
@@ -222,7 +222,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
             }
             // Compress controls: we only want a single control at one time
             if (Length(cs) > 1){
-                using (controlQubit = Qubit()){
+                use controlQubit = Qubit() {
                     CheckIfAllOnes(cs, controlQubit);
                     (Controlled EqualLookup)([controlQubit], (table, QuantumWrite, address));
                     (Adjoint CheckIfAllOnes)(cs, controlQubit);
@@ -255,7 +255,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
                         let h = 1 <<< (Length(address!) - 1);
                         let lowTable = table[0..h-1];
                         let highTable = table[h..Length(table)-1];
-                        using (q = Qubit()) {
+                        use q = Qubit() {
                             // Store 'all(controls) and not highBit' in q.
                             X(highBit);
                             if (Length(cs) > 0){
@@ -290,7 +290,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
             }
         }
         adjoint (...) {
-            (Controlled EqualLookup)(new Qubit[0], (table, (Adjoint QuantumWrite), address));
+            (Controlled EqualLookup)([], (table, (Adjoint QuantumWrite), address));
         }
         controlled adjoint (controls, ...){
             (Controlled EqualLookup)(controls, (table, (Adjoint QuantumWrite), address));
@@ -394,8 +394,8 @@ namespace Microsoft.Quantum.Crypto.Basics {
         let nPartitions = length/size;
         Fact((Length(array) % size) == 0, $"Cannot evenly partition array of length
             {Length(array)} into pieces of size {size}.");
-        mutable returnArray = new 'T[][nPartitions];
-        for (idx in 0.. nPartitions - 1){
+        mutable returnArray = [array, size = nPartitions];
+        for idx in 0.. nPartitions - 1 {
             set returnArray w/= idx <- array[size * idx .. size * (idx + 1) - 1];
         }
         return returnArray;
@@ -416,7 +416,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
         mutable randomBigInt = 0L;
         let nBits = 2 * BitSizeL(size);
         let maxInt = Min([nBits, 32]);
-        for (idx  in 0..nBits/maxInt-1){
+        for idx  in 0..nBits/maxInt-1 {
             set randomBigInt = (2L^maxInt) * randomBigInt + IntAsBigInt(DrawRandomInt(0,2^maxInt-1));
         }
         return randomBigInt % size;
@@ -521,7 +521,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
             secondOp(secondInputs);
         }
         controlled (controls,...){
-            using (innerControl = Qubit()){
+            use innerControl = Qubit() {
                 (Controlled X)(controls, (innerControl));
                 (Controlled firstOp)(controls, (firstInputs));
                 (Controlled secondOp)([innerControl], (secondInputs));
@@ -544,7 +544,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
     function HammingWeightL(value : BigInt) : Int {
         let valArray = BigIntAsBoolArray(value);
         mutable valHamWeight = 0;
-        for (idxVal in 0..Length(valArray)-1){
+        for idxVal in 0..Length(valArray)-1 {
             if (valArray[idxVal]){
                 set valHamWeight = valHamWeight+1;
             }
@@ -565,7 +565,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
     function HammingWeightI(value : Int) : Int {
         let valArray = IntAsBoolArray(value, BitSizeI(value));
         mutable valHamWeight = 0;
-        for (idxVal in 0..Length(valArray)-1){
+        for idxVal in 0..Length(valArray)-1 {
             if (valArray[idxVal]){
                 set valHamWeight = valHamWeight+1;
             }
@@ -593,10 +593,10 @@ namespace Microsoft.Quantum.Crypto.Basics {
         }
         controlled (controls, ...){
             let nQubits=Length(qubitArray);
-            using (singleControls = Qubit[nQubits]){
+            use singleControls = Qubit[nQubits] {
                 (Controlled X)(controls, singleControls[0]);
                 FanoutToZero(singleControls[0], singleControls[1..nQubits - 1]);
-                for (idx in 0..nQubits - 1){
+                for idx in 0..nQubits - 1 {
                     (Controlled op)([singleControls[idx]], (qubitArray[idx]));
                 }
                 (Adjoint FanoutToZero)(singleControls[0], singleControls[1..nQubits - 1]);
@@ -663,9 +663,9 @@ namespace Microsoft.Quantum.Crypto.Basics {
                 if (nQubits == 2){
                     (Controlled SWAP)(controls, (xs[0], xs[1]));
                 } elif (nQubits > 2){
-                    using (singleControls = Qubit[nControls]){
+                    use singleControls = Qubit[nControls] {
                         (Controlled FanoutControls)(controls,(singleControls));
-                        for (idxSwap in 0..nControls - 1){
+                        for idxSwap in 0..nControls - 1 {
                             (Controlled SWAP)([singleControls[idxSwap]], (xs[idxSwap], xs[nQubits - 1 - idxSwap]));
                         }
                         (Controlled Adjoint FanoutControls)(controls,(singleControls));
@@ -754,7 +754,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
             Fact (nCopyQubits % nQubits == 0, $"Cannot fanout {nQubits} qubits
                 to {nCopyQubits} qubits because it is not an even multiple");
         
-            for (idx in 0.. Length(register) - 1){
+            for idx in 0.. Length(register) - 1 {
                 FanoutToZero(register[idx], outputRegister[idx .. nQubits .. nCopyQubits - 1]);
             }
         }
@@ -763,9 +763,9 @@ namespace Microsoft.Quantum.Crypto.Basics {
             let nCopyQubits = Length(outputRegister);
             Fact (nCopyQubits % nQubits == 0, $"Cannot fanout {nQubits} qubits
                 to {nCopyQubits} qubits because it is not an even multiple");
-            using (singleControls = Qubit[nQubits]){
+            use singleControls = Qubit[nQubits] {
                 (Controlled FanoutControls)(controls, (singleControls));
-                for (idx in 0.. Length(register) - 1){
+                for idx in 0.. Length(register) - 1 {
                     (Controlled FanoutToZero)([singleControls[idx]], (register[idx], outputRegister[idx .. nQubits .. nCopyQubits - 1]));
                 }
                 (Controlled Adjoint FanoutControls)(controls, (singleControls));
@@ -860,7 +860,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
     /// The qubit that will be flipped
     operation CheckIfAllZero(xs : Qubit[], output : Qubit) : Unit {
         body (...){
-            (Controlled CheckIfAllZero)(new Qubit[0], (xs, output));
+            (Controlled CheckIfAllZero)([], (xs, output));
         }
         controlled (controls, ...){
             ApplyToEachWrapperCA(X, xs);
@@ -898,7 +898,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
                 if (IsMinimizeWidthCostMetric()) {
                     LinearMultiControl(xs, output);
                 } else { //high width but log-depth and small T-count
-                    using ((spareControls, ancillaOutput) = (Qubit[nQubits - 2], Qubit())){
+                    use (spareControls, ancillaOutput) = (Qubit[nQubits - 2], Qubit()) {
                         CompressControls(xs, spareControls, ancillaOutput);
                         CNOT(ancillaOutput, output);
                         (Adjoint CompressControls)(xs, spareControls, ancillaOutput);
@@ -938,21 +938,21 @@ namespace Microsoft.Quantum.Crypto.Basics {
             } elif (nQubits == 2){
                 CCNOTWrapper(controlQubits[0], controlQubits[1], output);
             } elif (nQubits <= 4){
-                borrowing (ancillaControl = Qubit()){
+                borrow ancillaControl = Qubit() {
                     LinearMultiControl(controlQubits[0.. nQubits -2], ancillaControl);
                     CCNOTWrapper(controlQubits[nQubits - 1], ancillaControl, output);
                     LinearMultiControl(controlQubits[0.. nQubits -2], ancillaControl);
                     CCNOTWrapper(controlQubits[nQubits - 1], ancillaControl, output);
                 }
             } elif (nQubits == 5) {
-                borrowing (ancillaControl = Qubit()){
+                borrow ancillaControl = Qubit() {
                     LinearMultiControl(controlQubits[0 .. nQubits - 3], ancillaControl);
                     LinearMultiControl(controlQubits[nQubits - 2 .. nQubits - 1] + [ancillaControl], output);
                     LinearMultiControl(controlQubits[0 .. nQubits - 3], ancillaControl);
                     LinearMultiControl(controlQubits[nQubits - 2 .. nQubits - 1] + [ancillaControl], output);
                 }
             } else {
-                borrowing (ancillaControl = Qubit()){
+                borrow ancillaControl = Qubit() {
                     let m = (nQubits + 1) / 2;
                     CascadeControl(controlQubits[0 .. m - 1], ancillaControl);
                     CascadeControl(controlQubits[m .. nQubits - 1] + [ancillaControl], output);
@@ -988,20 +988,20 @@ namespace Microsoft.Quantum.Crypto.Basics {
             if (nQubits <= 2){
                 LinearMultiControl(controlQubits, output);
             } else {
-                borrowing (ancillaControls = Qubit[nQubits - 2]){
+                borrow ancillaControls = Qubit[nQubits - 2] {
                     let ancillaTargets = [output] + ancillaControls;
-                    for (idx in 0 .. nQubits - 3){
+                    for idx in 0 .. nQubits - 3 {
                         CCNOTWrapper(controlQubits[idx], ancillaControls[idx], ancillaTargets[idx]);
                     }
                     CCNOTWrapper(controlQubits[nQubits - 2], controlQubits[nQubits -1], ancillaControls[nQubits - 3]);
-                    for (idx in nQubits - 3 .. (-1) .. 0){
+                    for idx in nQubits - 3 .. (-1) .. 0 {
                         CCNOTWrapper(controlQubits[idx], ancillaControls[idx], ancillaTargets[idx]);
                     }
-                    for (idx in 1 .. nQubits - 3){
+                    for idx in 1 .. nQubits - 3 {
                         CCNOTWrapper(controlQubits[idx], ancillaControls[idx], ancillaTargets[idx]);
                     }
                     CCNOTWrapper(controlQubits[nQubits - 2], controlQubits[nQubits -1], ancillaControls[nQubits - 3]);
-                    for (idx in nQubits - 3 .. (-1) .. 1){
+                    for idx in nQubits - 3 .. (-1) .. 1 {
                         CCNOTWrapper(controlQubits[idx], ancillaControls[idx], ancillaTargets[idx]);
                     }
                 }
@@ -1049,7 +1049,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
                     $"Cannot compress {nControls} control qubits into
                     {nNewControls} qubits because there are too few controls");
                 let compressLength = nControls - nNewControls;
-                for (idx in 0.. 2 .. nControls - 2){
+                for idx in 0.. 2 .. nControls - 2 {
                     AndWrapper(controlQubits[idx], controlQubits[idx + 1], blankControlQubits[idx/2]);
                 }
                 if (nControls % 2 == 0){
@@ -1094,25 +1094,25 @@ namespace Microsoft.Quantum.Crypto.Basics {
     /// Test again. 
     operation QuantumWhile(lowerBound : Int, upperBound : Int, Body : ((Int)=>Unit is Ctl + Adj), test : ((Qubit)=>Unit is Ctl + Adj), Alternate : ((Int)=>Unit is Ctl + Adj), counter : Counter) : Unit{
         body (...){
-            (Controlled QuantumWhile)(new Qubit[0], (lowerBound, upperBound, Body, test, Alternate, counter));
+            (Controlled QuantumWhile)([], (lowerBound, upperBound, Body, test, Alternate, counter));
         }	
         controlled (controls, ...){
             Fact(upperBound>lowerBound, $"Upper bound ({upperBound}) must be higher than lower bound ({lowerBound})");
             Fact(upperBound-lowerBound<counter::period, $"Counter's period is {counter::period} but may need to count {upperBound-lowerBound} iterations");
-            using (mainControl = Qubit()){
+            use mainControl = Qubit() {
 	    	    // Use the main control if there are too many controls
 	    	    if (Length(controls) > 1){
 		    	    CheckIfAllOnes(controls, mainControl);
-			        for (roundNum in 0..lowerBound - 1){
+			        for roundNum in 0..lowerBound - 1 {
 			            (Controlled Body)([mainControl], (roundNum));
 			        }
 			        (Adjoint CheckIfAllOnes)(controls, mainControl);
 		        } else {
-	    	        for (roundNum in 0..lowerBound - 1){
+	    	        for roundNum in 0..lowerBound - 1 {
 			   	        (Controlled Body)(controls, (roundNum));
 			        }
 	           }
-	  	    for (roundNum in lowerBound..upperBound-1){
+	  	    for roundNum in lowerBound..upperBound-1 {
                     //Logic here : maincontrol is initially 0
                     //When the test does nothing and the counter is all 1s : 
                     //		It runs Body[idxRound], does not increment
@@ -1128,7 +1128,7 @@ namespace Microsoft.Quantum.Crypto.Basics {
                     //Checks if the counter is non-start
                     counter::Test(mainControl);
                     //Fanout the main control to save depth
-                    using (extraControls = Qubit[2]){
+                    use extraControls = Qubit[2] {
                         CNOT(mainControl,extraControls[0]);
                         CNOT(extraControls[0],extraControls[1]);
                         //Runs the body if maincontrol is 0

--- a/MicrosoftQuantumCrypto/Counters.qs
+++ b/MicrosoftQuantumCrypto/Counters.qs
@@ -66,7 +66,7 @@ namespace Microsoft.Quantum.Crypto.NC.SpecialCounters {
     /// `counter` is not in its zero state.
     operation TestSpecialCounter(counter : Qubit[], target : Qubit) : Unit {
         body (...) {
-            (Controlled TestSpecialCounter)(new Qubit[0], (counter, target));
+            (Controlled TestSpecialCounter)([], (counter, target));
         }
         controlled(controls, ...){
             (Controlled CheckIfAllOnes)(controls, (counter, target));
@@ -117,13 +117,13 @@ namespace Microsoft.Quantum.Crypto.NC.SpecialCounters {
     /// Qubit register of the counter to increment.
     operation IncrementSpecialCounter(counter : Qubit[]) : Unit {
         body (...) {
-            (Controlled IncrementSpecialCounter)(new Qubit[0], (counter));
+            (Controlled IncrementSpecialCounter)([], (counter));
         }
         controlled (controls, ...){
             let nQubits=Length(counter);
             (Controlled CyclicRotateRegister)(controls, LittleEndian(counter));
             let polynomial = _PrimitiveGF2Polynomial(nQubits);
-            for (idp in 0..Length(polynomial) - 1){
+            for idp in 0..Length(polynomial) - 1 {
                 (Controlled CNOT)(controls, (counter[0], counter[polynomial[idp]]));
             }
         }

--- a/MicrosoftQuantumCrypto/EllipticCurves.qs
+++ b/MicrosoftQuantumCrypto/EllipticCurves.qs
@@ -188,7 +188,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
         mutable remainingCoefficient = coefficient;
         mutable doubledPoint = point;
         let coefficientBools = BigIntAsBoolArray(coefficient);
-        for (idx in 0 .. Length(coefficientBools) - 1){	
+        for idx in 0 .. Length(coefficientBools) - 1 {	
             if (coefficientBools[idx]){
                 set outputPoint = AddClassicalECPoint(outputPoint, doubledPoint, curve::a);
             }
@@ -268,7 +268,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
     /// Quantum register to write into
     operation EncodeClassicalECPointInQuantum(inputPoint : ECPointClassical, outputPoint : ECPointMontgomeryForm) : Unit {
         body (...) {
-            (Controlled EncodeClassicalECPointInQuantum)(new Qubit[0], (inputPoint, outputPoint));
+            (Controlled EncodeClassicalECPointInQuantum)([], (inputPoint, outputPoint));
         }
         controlled (controls, ...){
             Fact(inputPoint::modulus == outputPoint::xs::modulus,
@@ -393,7 +393,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
     ///     * `point1`+`point2` does not equal `-point1
     operation DistinctEllipticCurvePointAddition(point1 : ECPointMontgomeryForm, point2 : ECPointMontgomeryForm) : Unit {
         body (...){
-            (Controlled DistinctEllipticCurvePointAddition)(new Qubit[0], (point1, point2));
+            (Controlled DistinctEllipticCurvePointAddition)([], (point1, point2));
         }
         controlled (controls, ...){
             let nQubits = Length(point1::xs::register!);
@@ -402,7 +402,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
             (Adjoint ModularAddMontgomeryForm)(point1::xs, point2::xs);
             (Adjoint Controlled ModularAddMontgomeryForm)(controls, (point1::ys, point2::ys));
 
-            using (lambdaqubits = Qubit[nQubits]){
+            use lambdaqubits = Qubit[nQubits] {
                 let lambdas = MontModInt(modulus, LittleEndian(lambdaqubits));
                 //Computes lambda in a new register
                 (Controlled ModularDivideAndAddMontgomeryForm)(controls, (point2::xs, point2::ys, lambdas));
@@ -455,7 +455,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
     ///     * `point1`+`point2` does not equal `-point1`
     operation DistinctEllipticCurveClassicalPointAddition(point1 : ECPointClassical, point2 : ECPointMontgomeryForm) : Unit {
         body (...){
-            (Controlled DistinctEllipticCurveClassicalPointAddition)(new Qubit[0], (point1, point2));
+            (Controlled DistinctEllipticCurveClassicalPointAddition)([], (point1, point2));
         }
         controlled (controls, ...){
             if (point1::z){
@@ -464,7 +464,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
                 // Set the second point to x2-x1 and y2-y1
                 (Adjoint ModularAddConstantMontgomeryForm)(point1::x, point2::xs);
                 (Adjoint Controlled ModularAddConstantMontgomeryForm)(controls, (point1::y, point2::ys));
-                using (lambdaqubits = Qubit[nQubits]){
+                use lambdaqubits = Qubit[nQubits] {
                     let lambdas = MontModInt(modulus, LittleEndian(lambdaqubits));
                     (Controlled ModularDivideAndAddMontgomeryForm)(controls, (point2::xs, point2::ys, lambdas));
                     //Clears y2-y1 using lambda and x2-x1
@@ -507,7 +507,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
     /// as this is intended for use in windowed point addition
     operation ECPointWrite (inputPoint : ECPointClassical, outputPoint : ECPointMontgomeryForm, outputZ : Qubit) : Unit {
         body (...){
-            (Controlled ECPointWrite)(new Qubit[0], (inputPoint, outputPoint, outputZ));
+            (Controlled ECPointWrite)([], (inputPoint, outputPoint, outputZ));
         }
         controlled (controls, ...){
             let modulus = inputPoint::modulus;
@@ -546,13 +546,13 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
     /// these points "at once" with a single fully-quantum point addition.
     operation WindowedEllipticCurvePointAddition(points : ECPointClassical[], address : LittleEndian, point : ECPointMontgomeryForm) : Unit {
         body (...){
-            (Controlled WindowedEllipticCurvePointAddition)(new Qubit[0], (points, address, point));
+            (Controlled WindowedEllipticCurvePointAddition)([], (points, address, point));
         }
         controlled (controls, ...){
             let modulus = point::xs::modulus;
             let nQubits = Length(point::xs::register!);
 
-            using (ancillaPointQubits = Qubit[2 * nQubits + 1]){
+            use ancillaPointQubits = Qubit[2 * nQubits + 1] {
                 //Format new qubits into a point
                 let ancillaPoint = ECPointMontgomeryForm(
                     MontModInt(modulus, LittleEndian(ancillaPointQubits[0..nQubits - 1])),
@@ -626,16 +626,16 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
     /// but should use fewer qubits.
     operation WindowedEllipticCurvePointAdditionLowWidth(points : ECPointClassical[], address : LittleEndian, point : ECPointMontgomeryForm) : Unit {
         body (...){
-            (Controlled WindowedEllipticCurvePointAdditionLowWidth)(new Qubit[0], (points, address, point));
+            (Controlled WindowedEllipticCurvePointAdditionLowWidth)([], (points, address, point));
         }
         controlled (controls, ...){
             let modulus = point::xs::modulus;
             let nQubits = Length(point::xs::register!);
-            using (zQubit = Qubit()){
+            use zQubit = Qubit() {
                 // Set the second point to x2-x1 and y2-y1
                 // This requires a QRAM look-up
                 // Here we also set the zQubit (which controls other operations)
-                using (ancillaPointQubits = Qubit[2 * nQubits + 1]){
+                use ancillaPointQubits = Qubit[2 * nQubits + 1] {
                     let ancillaPoint = ECPointMontgomeryForm(
                         MontModInt(modulus, LittleEndian(ancillaPointQubits[0..nQubits - 1])),
                         MontModInt(modulus, LittleEndian(ancillaPointQubits[nQubits .. 2 * nQubits - 1]))
@@ -647,14 +647,14 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
                     (Controlled CNOT)(controls, (ancillaZ, zQubit));				
                     (Controlled Adjoint EqualLookup)(controls, (points, ECPointWrite(_, ancillaPoint, ancillaZ), address));
                 }
-                using (lambdaqubits = Qubit[nQubits]){
+                use lambdaqubits = Qubit[nQubits] {
                     let lambdas = MontModInt(modulus, LittleEndian(lambdaqubits));
                     (Controlled ModularDivideAndAddMontgomeryForm)(controls + [zQubit], (point::xs, point::ys, lambdas));
                     //Clears y2-y1 using lambda and x2-x1
                     ModularMulAndXorMontgomeryForm(point::xs, lambdas, point::ys);
                     //Adds 3x1 to x2-x1 to get x2+2x1
                     //This needs another QRAM look-up
-                    using (ancillaPointQubits = Qubit[nQubits]){
+                    use ancillaPointQubits = Qubit[nQubits] {
                         let xsMMI = MontModInt(modulus, LittleEndian(ancillaPointQubits[0..nQubits - 1]));
                         (Controlled EqualLookup)(controls, (points, _ClassicalECPointFormat(_, xsMMI), address));
                         (Controlled ModularAddMontgomeryForm)(controls, (xsMMI, point::xs));
@@ -668,7 +668,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
                     (Adjoint Controlled ModularDivideAndAddMontgomeryForm)(controls + [zQubit], (point::xs, point::ys, lambdas));
                 }
                 // Adds all required constants in one go
-                using (ancillaPointQubits = Qubit[2 * nQubits + 1]){
+                use ancillaPointQubits = Qubit[2 * nQubits + 1] {
                     let ancillaPoint = ECPointMontgomeryForm(
                         MontModInt(modulus, LittleEndian(ancillaPointQubits[0..nQubits - 1])),
                         MontModInt(modulus, LittleEndian(ancillaPointQubits[nQubits .. 2 * nQubits - 1]))
@@ -719,10 +719,10 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
     /// [b - 2^k]P to the register.
     operation SignedWindowedEllipticCurvePointAdditionLowWidth(points : ECPointClassical[], address : Qubit[], point : ECPointMontgomeryForm) : Unit {
         body (...){
-            (Controlled SignedWindowedEllipticCurvePointAdditionLowWidth)(new Qubit[0], (points, address, point));
+            (Controlled SignedWindowedEllipticCurvePointAdditionLowWidth)([], (points, address, point));
         }
         controlled (controls, ...){
-            using (addressAncilla = Qubit()){
+            use addressAncilla = Qubit() {
                 let addressLength = Length(address);
                 let unsignedAddress = address[0 .. addressLength - 2];
                 let leftAddress = LittleEndian(unsignedAddress + [addressAncilla]);
@@ -739,8 +739,8 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
                 // This requires a QRAM look-up
                 // Here we also set the zQubit (which controls other operations)
                 if (nQubits > 50){Message($"{nQubits}-bit modulus: First look-up");}
-                using (zQubit = Qubit()){
-                    using (ancillaPointQubits = Qubit[2 * nQubits]){
+                use zQubit = Qubit() {
+                    use ancillaPointQubits = Qubit[2 * nQubits] {
                         let ancillaPoint = ECPointMontgomeryForm(
                             MontModInt(modulus, LittleEndian(ancillaPointQubits[0..nQubits - 1])),
                             MontModInt(modulus, LittleEndian(ancillaPointQubits[nQubits .. 2 * nQubits - 1]))
@@ -756,7 +756,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
                         (Controlled ModularNegMontgomeryForm)([signQubit], (ancillaPoint::ys));
                         (Controlled Adjoint EqualLookup)(controls, (points, EncodeClassicalECPointInQuantum(_, ancillaPoint), leftAddress));
                     }
-                    using (lambdaqubits = Qubit[nQubits]){
+                    use lambdaqubits = Qubit[nQubits] {
                         let lambdas = MontModInt(modulus, LittleEndian(lambdaqubits));
                         if (nQubits > 50){Message($"{nQubits}-bit modulus: First division");}
                         (Controlled ModularDivideAndAddMontgomeryForm)(controls + [zQubit], (point::xs, point::ys, lambdas));
@@ -766,7 +766,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
                         //Adds 3x1 to x2-x1 to get x2+2x1
                         //This needs another QRAM look-up
                         if (nQubits > 50){Message($"{nQubits}-bit modulus: Second look-up");}
-                        using (ancillaPointQubits = Qubit[nQubits]){
+                        use ancillaPointQubits = Qubit[nQubits] {
                             let xsMMI = MontModInt(modulus, LittleEndian(ancillaPointQubits[0..nQubits - 1]));
                             // Look up 3*(x-value) of the classical point
                             (Controlled EqualLookup)(controls, (points, _ClassicalECPointFormat(_, xsMMI), leftAddress));
@@ -785,7 +785,7 @@ namespace Microsoft.Quantum.Crypto.EllipticCurves {
                         (Adjoint Controlled ModularDivideAndAddMontgomeryForm)(controls + [zQubit], (point::xs, point::ys, lambdas));
                     }
                     // Adds all required constants in one go
-                    using (ancillaPointQubits = Qubit[2 * nQubits + 1]){
+                    use ancillaPointQubits = Qubit[2 * nQubits + 1] {
                         if (nQubits > 50){Message($"{nQubits}-bit modulus: Third look-up");}
                         let ancillaPoint = ECPointMontgomeryForm(
                             MontModInt(modulus, LittleEndian(ancillaPointQubits[0..nQubits - 1])),

--- a/MicrosoftQuantumCrypto/Fp2Arithmetic.qs
+++ b/MicrosoftQuantumCrypto/Fp2Arithmetic.qs
@@ -358,7 +358,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
             ModularNegMontgomeryForm(abs::imags);
         }
             controlled (controls, ...){
-            using (singleControls = Qubit[2]){
+            use singleControls = Qubit[2] {
                 (Controlled X)(controls, (singleControls[0]));
                 CNOT(singleControls[0], singleControls[1]);
                 (Controlled ModularNegMontgomeryForm)([singleControls[0]], (abs::reals));
@@ -404,7 +404,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
             ModularDblMontgomeryForm(abs::imags);
         }
         controlled (controls, ...){
-            using (singleControls = Qubit[2]){
+            use singleControls = Qubit[2] {
                 (Controlled X)(controls, (singleControls[0]));
                 CNOT(singleControls[0], singleControls[1]);
                 (Controlled ModularDblMontgomeryForm)([singleControls[0]], (abs::reals));
@@ -431,7 +431,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
     /// with the result.
     operation AddFp2ElementMontgomeryForm(abs : Fp2MontModInt, cds : Fp2MontModInt) : Unit {
         body (...){
-            (Controlled AddFp2ElementMontgomeryForm)(new Qubit[0], (abs, cds));
+            (Controlled AddFp2ElementMontgomeryForm)([], (abs, cds));
         }
         controlled (controls, ...){
             (Controlled ModularAddMontgomeryForm)(controls, (abs::reals, cds::reals));
@@ -460,7 +460,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
             CopyLittleEndian(source::imags::register, target::imags::register);
         }
         controlled (controls, ...){
-            using (spareControl = Qubit()){
+            use spareControl = Qubit() {
                 (Controlled X)(controls, (spareControl));
                 (Controlled CopyLittleEndian)(controls, (source::reals::register, target::reals::register) );
                 (Controlled CopyLittleEndian)([spareControl], (source::imags::register, target::imags::register));
@@ -489,7 +489,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
             SwapLE(input1::imags::register, input2::imags::register);
         }
         controlled (controls, ...){
-            using (singleControl = Qubit()){
+            use singleControl = Qubit() {
                 (Controlled X)(controls, (singleControl));
                 (Controlled SwapLE)(controls, (input1::reals::register, input2::reals::register));
                 (Controlled SwapLE)([singleControl], (input1::imags::register, input2::imags::register));
@@ -540,7 +540,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
     /// This saves roughly 6 additions compared to addition into `blankOutputs`	
     operation MulAndXorFp2ElementMontgomeryForm(abs : Fp2MontModInt, cds : Fp2MontModInt, blankOutputs : Fp2MontModInt) : Unit {
         body(...){
-            (Controlled MulAndXorFp2ElementMontgomeryForm)(new Qubit[0], (abs, cds, blankOutputs));
+            (Controlled MulAndXorFp2ElementMontgomeryForm)([], (abs, cds, blankOutputs));
         }
         controlled (controls, ...){
             // Given input (a+bi) and (c+di)
@@ -586,7 +586,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
     /// Qubit register containing e+fi which will be added to the product.
     operation MulAndAddFp2ElementMontgomeryForm(abs : Fp2MontModInt, cds : Fp2MontModInt, outputs : Fp2MontModInt) : Unit {
         body(...){
-            (Controlled MulAndAddFp2ElementMontgomeryForm)(new Qubit[0], (abs, cds, outputs));
+            (Controlled MulAndAddFp2ElementMontgomeryForm)([], (abs, cds, outputs));
         }
         controlled (controls, ...){		
             // Given output x+yi
@@ -809,7 +809,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
     /// Qubit register containing e+fi and will contain the output.
     operation MulByConstantAndAddFp2MontgomeryFormGeneric(constant : Fp2ElementClassical, abs : Fp2MontModInt, outputs : Fp2MontModInt) : Unit {
         body (...){
-            (Controlled MulByConstantAndAddFp2MontgomeryFormGeneric)(new Qubit[0], (constant, abs, outputs));
+            (Controlled MulByConstantAndAddFp2MontgomeryFormGeneric)([], (constant, abs, outputs));
         }
         controlled (controls, ...){
             let nQubits = Length(abs::reals::register!);
@@ -860,7 +860,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
     /// or adding the result to `absquareds`
     operation SquareFp2ElementMontgomeryFormGeneric(abs : Fp2MontModInt, absquareds : Fp2MontModInt, Multiplier : ((MontModInt, MontModInt, MontModInt)=>Unit is Ctl+Adj)) : Unit {
         body (...){
-            (Controlled SquareFp2ElementMontgomeryFormGeneric)(new Qubit[0], (abs, absquareds, Multiplier));
+            (Controlled SquareFp2ElementMontgomeryFormGeneric)([], (abs, absquareds, Multiplier));
         }
         controlled (controls, ...){
             ModularDblMontgomeryForm(abs::imags);
@@ -994,7 +994,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
             (Adjoint ModularMulAndAddMontgomeryForm)(freeInputs, abs::imags, cds::imags);
         }
         controlled (controls, ...){
-            using (singleControls = Qubit[2]){
+            use singleControls = Qubit[2] {
                 (Controlled X)(controls, (singleControls[0]));
                 CNOT(singleControls[0], singleControls[1]);
                 (Controlled ModularMulAndAddMontgomeryForm)([singleControls[0]], (freeInputs, abs::reals, cds::reals));
@@ -1018,12 +1018,12 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
     /// Qubit register to which the inverse will be added.
     operation InvertAndAddFp2ElementMontgomeryForm(abs : Fp2MontModInt, cds : Fp2MontModInt) : Unit {
         body (...){
-            (Controlled InvertAndAddFp2ElementMontgomeryForm)(new Qubit[0], (abs, cds));
+            (Controlled InvertAndAddFp2ElementMontgomeryForm)([], (abs, cds));
         }
         controlled (controls, ...){
             let DoubleFp2WithInteger = DummyIntegerWrapper(Adjoint DblFp2MontgomeryForm, cds, _);
             let nQubits = Length(abs::reals::register!);
-            using (squares = Qubit[nQubits]){
+            use squares = Qubit[nQubits] {
                 let squaresMontgomery = MontModInt(abs::modulus, LittleEndian(squares));
                 ModularSquMontgomeryFormGeneric(CopyMontModInt(_, squaresMontgomery), abs::reals);
                 ModularSquMontgomeryFormGeneric(ModularAddMontgomeryForm(_, squaresMontgomery), abs::imags);
@@ -1061,7 +1061,7 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
     /// fixed as $(a^2+b^2)^{-1}$ is uncomputed.
     operation _MultiplyFp2InDivision(xNormInvs : MontModInt, abs : Fp2MontModInt, cds : Fp2MontModInt, efs : Fp2MontModInt) : Unit {
         body (...){
-            (Controlled _MultiplyFp2InDivision)(new Qubit[0], (xNormInvs, abs, cds, efs));
+            (Controlled _MultiplyFp2InDivision)([], (xNormInvs, abs, cds, efs));
         }
         controlled (controls, ...){
             //Input is expected to be : 
@@ -1124,12 +1124,12 @@ namespace Microsoft.Quantum.Crypto.Fp2Arithmetic {
     /// keeps the ancilla from the inversion steps while it computes the rest.
     operation DivideAndAddFp2ElementMontgomeryForm(abs : Fp2MontModInt, cds : Fp2MontModInt, efs : Fp2MontModInt) : Unit {
         body (...){
-            (Controlled DivideAndAddFp2ElementMontgomeryForm)(new Qubit[0], (abs, cds, efs));
+            (Controlled DivideAndAddFp2ElementMontgomeryForm)([], (abs, cds, efs));
         }
         controlled (controls, ...){
             let nQubits = Length(abs::reals::register!);
             let DoubleFp2WithInteger = DummyIntegerWrapper(Adjoint DblFp2MontgomeryForm, efs, _);
-            using (squares = Qubit[nQubits]){
+            use squares = Qubit[nQubits] {
                 //Given abs = a+bi
                 //	    cds = c+di
                 //      efs = e+fi

--- a/MicrosoftQuantumCrypto/IsMinimizeDepthCostMetric.cs
+++ b/MicrosoftQuantumCrypto/IsMinimizeDepthCostMetric.cs
@@ -1,3 +1,4 @@
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
@@ -15,7 +16,7 @@ namespace Microsoft.Quantum.Crypto.Basics
             {
             }
 
-            public override Func<QVoid, bool> Body => IsMinimizeDepthCostMetricFunc;
+           public override Func<QVoid, bool> __Body__ => IsMinimizeDepthCostMetricFunc;
 
             public static bool IsMinimizeDepthCostMetricFunc(QVoid qVoid)
             {

--- a/MicrosoftQuantumCrypto/IsMinimizeTCostMetric.cs
+++ b/MicrosoftQuantumCrypto/IsMinimizeTCostMetric.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Crypto.Basics
             {
             }
 
-            public override Func<QVoid, bool> Body => IsMinimizeTCostMetricFunc;
+            public override Func<QVoid, bool> __Body__ => IsMinimizeTCostMetricFunc;
 
             public static bool IsMinimizeTCostMetricFunc(QVoid qVoid)
             {

--- a/MicrosoftQuantumCrypto/IsMinimizeWidthCostMetric.cs
+++ b/MicrosoftQuantumCrypto/IsMinimizeWidthCostMetric.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Crypto.Basics
             {
             }
 
-            public override Func<QVoid, bool> Body => IsMinimizeWidthCostMetricFunc;
+            public override Func<QVoid, bool> __Body__ => IsMinimizeWidthCostMetricFunc;
 
             public static bool IsMinimizeWidthCostMetricFunc(QVoid qVoid)
             {

--- a/MicrosoftQuantumCrypto/IsTestable.cs
+++ b/MicrosoftQuantumCrypto/IsTestable.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Crypto.Basics
             {
             }
 
-            public override Func<QVoid, bool> Body => IsTestableFunc;
+            public override Func<QVoid, bool> __Body__ => IsTestableFunc;
 
             public static bool IsTestableFunc(QVoid qVoid)
             {

--- a/MicrosoftQuantumCrypto/MicrosoftQuantumCrypto.csproj
+++ b/MicrosoftQuantumCrypto/MicrosoftQuantumCrypto.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082513">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.24.208024">
 
   <PropertyGroup>
     <OutputType>library</OutputType>
@@ -22,8 +22,8 @@
 
   <ItemGroup>
     <PackageReference Include="filehelpers" Version="3.4.1" />
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.12.20082513" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.20082513" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.24.208024" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.24.208024" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/MicrosoftQuantumCrypto/ModularArithmetic.qs
+++ b/MicrosoftQuantumCrypto/ModularArithmetic.qs
@@ -149,13 +149,13 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     /// as a modular addition between two qubit registers.
     operation ModularAddConstantConstantModulusSimple(constant : BigInt, modulus : BigInt, xs : LittleEndian) : Unit {
         body (...){
-            (Controlled ModularAddConstantConstantModulusSimple)(new Qubit[0], (constant%modulus, modulus, xs));
+            (Controlled ModularAddConstantConstantModulusSimple)([], (constant%modulus, modulus, xs));
         }
         controlled (controls, ...){
             if (constant>=modulus){
                 (Controlled ModularAddConstantConstantModulusSimple)(controls, (constant%modulus, modulus, xs));
             } else {
-                using (carry = Qubit()){
+                use carry = Qubit() {
                     (Controlled AddConstant)(controls, (constant, LittleEndian(xs!+[carry])));
                     (Controlled Adjoint AddConstant)(controls, (modulus, LittleEndian(xs!+[carry])));
                     (Controlled AddConstant)(controls+[carry], (modulus, xs));
@@ -210,7 +210,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 nQubits == Length(ys!), true, 
                 "Input register ys must have the same number of qubits as the modulus." );
 
-            using ( carry = Qubit() ) {
+            use  carry = Qubit()  {
                 AddInteger(xs, ys, carry);
                 (Adjoint AddInteger)(ms, ys, carry); 
                 (Controlled AddIntegerNoCarry)([carry], (ms, ys));
@@ -245,7 +245,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     operation ModularNeg (xs : LittleEndian, ms : LittleEndian) : Unit
     {
         body (...) {
-            (Controlled ModularNeg) (new Qubit[0], (xs, ms));
+            (Controlled ModularNeg) ([], (xs, ms));
         }
         adjoint auto;
         controlled ( controls, ... ) {
@@ -254,7 +254,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
             EqualityFactB(
                 nQubits == Length(xs!), true, 
                 "Input register xs must have the same number of qubits as the modulus." );
-            using (isAllZeros = Qubit()){
+            use isAllZeros = Qubit() {
                 (Controlled X)(controls, isAllZeros);
                 // Test if input is zero; it should remain zero
                 (Controlled CheckIfAllZero)(controls, (xs!, isAllZeros));
@@ -293,7 +293,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     operation ModularDbl (xs : LittleEndian, ms : LittleEndian) : Unit
     {
         body (...) {
-            (Controlled ModularDbl) (new Qubit[0], (xs, ms));
+            (Controlled ModularDbl) ([], (xs, ms));
         }
         adjoint auto;
         controlled (controls, ...) {
@@ -303,7 +303,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 nQubits == Length(xs!), true, 
                 "Input register xs must have the same number of qubits as the modulus." );
 
-            using ((carry, control) = (Qubit(), Qubit())) {
+            use (carry, control) = (Qubit(), Qubit()) {
                 let xxs = LittleEndian( xs! + [carry] );
 
                 (Controlled CyclicRotateRegister) (controls, xxs);
@@ -360,7 +360,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 nQubits == Length(zs!), true, 
                 "Output register zs must have the same number of qubits as the modulus." );
 
-            for (idx in nQubits-1 ..(-1).. 1) {
+            for idx in nQubits-1 ..(-1).. 1 {
                 (Controlled ModularAdd)([xs![idx]], (ys, zs, ms));
                 ModularDbl(zs, ms);
             }
@@ -401,7 +401,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     operation ModularSquDblAdd (xs : LittleEndian, zs : LittleEndian, ms : LittleEndian) : Unit
     {
         body (...) {
-            (Controlled ModularSquDblAdd) (new Qubit[0], (xs, zs, ms));
+            (Controlled ModularSquDblAdd) ([], (xs, zs, ms));
         }
         adjoint auto;
         controlled ( controls, ... ) {
@@ -414,8 +414,8 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 nQubits == Length(zs!), true, 
                 "Output register zs must have the same number of qubits as the modulus." );
 
-            using (xsBitcopy = Qubit[1]) {
-                for (idx in nQubits-1 ..(-1).. 1) {
+            use xsBitcopy = Qubit[1] {
+                for idx in nQubits-1 ..(-1).. 1 {
                     (Controlled CNOT) (controls, (xs![idx], xsBitcopy[0]));
                     (Controlled ModularAdd)(xsBitcopy, (xs, zs, ms));
                     (Controlled CNOT) (controls, (xs![idx], xsBitcopy[0]));
@@ -456,7 +456,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     operation ModularAddConstantModulus (modulus : BigInt, xs : LittleEndian, ys : LittleEndian) : Unit
     {
         body (...) {
-            (Controlled ModularAddConstantModulus) (new Qubit[0], (modulus, xs, ys));
+            (Controlled ModularAddConstantModulus) ([], (modulus, xs, ys));
         }
         adjoint auto;
         controlled (controls, ...) {
@@ -466,7 +466,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 nQubits == Length(ys!), true, 
                 "Input register xs and ys must have the same number of qubits." );
 
-            using (carry = Qubit[1]) {
+            use carry = Qubit[1] {
                 (Controlled AddInteger) (controls, (xs, ys, carry[0])); 
                 (Adjoint AddConstant)(modulus, LittleEndian(ys! + carry));
                 (Controlled AddConstant) (carry, (modulus, ys));
@@ -505,7 +505,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     operation ModularDblConstantModulus (modulus : BigInt, xs : LittleEndian) : Unit
     {
         body (...) {
-            (Controlled ModularDblConstantModulus) (new Qubit[0], (modulus, xs));
+            (Controlled ModularDblConstantModulus) ([], (modulus, xs));
         }
         adjoint auto;
         controlled (controls, ...) {
@@ -515,7 +515,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 modulus % 2L == 1L, true, 
                 "ModularDbl requires modulus to be odd." );
 
-            using ( ancillas = Qubit[1] ) {
+            use  ancillas = Qubit[1]  {
                 let carry = ancillas[0];
                 let xxs = LittleEndian( xs! + [carry] );
 
@@ -557,13 +557,13 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     operation ModularAddConstantConstantModulusLowT (constant : BigInt, modulus : BigInt, xs : LittleEndian) : Unit
     {
         body (...) {
-            (Controlled ModularAddConstantConstantModulusLowT) (new Qubit[0], (constant, modulus, xs));
+            (Controlled ModularAddConstantConstantModulusLowT) ([], (constant, modulus, xs));
         }
         adjoint auto;
         controlled (controls, ...) {
             let nQubits = Length(xs!);
             
-            using (carry = Qubit[1]) {
+            use carry = Qubit[1] {
                 ApplyToEachWrapperCA(X, xs!);
                 (Controlled ComputeCarry) (controls, (modulus - constant, xs, carry[0]));
                 ApplyToEachWrapperCA(X, xs!);
@@ -619,7 +619,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 nQubits == Length(zs!), true, 
                 "Output register zs must have the same number of qubits as the modulus." );
 
-            for (idx in nQubits-1 ..(-1).. 1) {
+            for idx in nQubits-1 ..(-1).. 1 {
                 (Controlled ModularAddConstantModulus)([xs![idx]], (modulus, ys, zs));
                 ModularDblConstantModulus(modulus, zs);
             }
@@ -657,7 +657,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     operation ModularSquDblAddConstantModulus (modulus : BigInt, xs : LittleEndian, zs : LittleEndian) : Unit
     {
         body (...) {
-            (Controlled ModularSquDblAddConstantModulus) (new Qubit[0], (modulus, xs, zs));
+            (Controlled ModularSquDblAddConstantModulus) ([], (modulus, xs, zs));
         }
         adjoint auto;
         controlled ( controls, ... ) {
@@ -666,8 +666,8 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 nQubits == Length(zs!), true, 
                 "Output register zs must have the same number of qubits as the modulus." );
 
-            using (xsBitcopy = Qubit[1]) {
-                for (idx in nQubits-1 ..(-1).. 1) {
+            use xsBitcopy = Qubit[1] {
+                for idx in nQubits-1 ..(-1).. 1 {
                     (Controlled CNOT) (controls, (xs![idx], xsBitcopy[0]));
                     (Controlled ModularAddConstantModulus)(xsBitcopy, (modulus, xs, zs));
                     (Controlled CNOT) (controls, (xs![idx], xsBitcopy[0]));
@@ -709,7 +709,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     {
         body (...) {
             let negModulus = 2L^Length(xs!) - modulus - 1L;
-            using (isAllZeros = Qubit()){
+            use isAllZeros = Qubit() {
                 //Test if the input is all-zeros
                 CheckIfAllZero(xs!, isAllZeros);
                 //If all-zeros, then put the modulus in xs
@@ -725,7 +725,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
         }
         controlled (controls, ...) {
             let negModulus = 2L^Length(xs!) - modulus - 1L;
-            using (isAllZeros = Qubit()){
+            use isAllZeros = Qubit() {
                 (Controlled CheckIfAllZero)(controls, (xs!, isAllZeros));
                 (Controlled ApplyXorInPlaceL)([isAllZeros], (modulus, xs));
                 (Controlled AddConstant)(controls, (negModulus, xs));
@@ -762,11 +762,11 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     ///   except "classically curried" over "x"
     operation ModularMulByConstantConstantModulus(modulus : BigInt, constant : BigInt, xs : LittleEndian, ys : LittleEndian) : Unit{
         body (...) { 
-            (Controlled ModularMulByConstantConstantModulus) (new Qubit[0], (modulus, constant, xs, ys));
+            (Controlled ModularMulByConstantConstantModulus) ([], (modulus, constant, xs, ys));
         }
         controlled (controls, ... ){
             let constantAsArray = BigIntAsBoolArray(constant);
-            for (idx in Length(constantAsArray)-1 ..(-1)..1){
+            for idx in Length(constantAsArray)-1 ..(-1)..1 {
                 if (constantAsArray[idx]){
                     (Controlled ModularAddConstantModulus)(controls, (modulus, xs, ys));
                 }
@@ -798,14 +798,14 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     /// twice, once in Adjoint, using c and c^-1.
     operation ModularMulByConstantConstantModulusInPlace(modulus : BigInt, constant : BigInt, xs : LittleEndian) : Unit {
         body (...) {
-            (Controlled ModularMulByConstantConstantModulusInPlace)(new Qubit[0], (modulus, constant, xs));
+            (Controlled ModularMulByConstantConstantModulusInPlace)([], (modulus, constant, xs));
         }
         controlled (controls, ...) {
             EqualityFactL(GreatestCommonDivisorL(constant, modulus), 1L, 
                 $"Cannot multiply by {constant} in-place modulo {modulus} because they are not co-prime"
             );
             let constantinv = InverseModL(constant, modulus);
-            using (ys = Qubit[Length(xs!)]){
+            use ys = Qubit[Length(xs!)] {
                 let ysLE = LittleEndian(ys);
                 (Controlled SwapLE)(controls, (xs, ysLE));
                 (Controlled ModularMulByConstantConstantModulus)(controls, (modulus, constant, ysLE, xs));
@@ -1270,9 +1270,9 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
             AssertEnoughQubits(nSelfOutputs, "Montgomery multiplication output: ", blankOutputs::register!);
             let ms = ancillas[0 .. nQubits - 1];
             
-            using ((ysCarry, testCarry) = (Qubit[1], Qubit())){//only necessary to match the number of qubits for the adder
+            use (ysCarry, testCarry) = (Qubit[1], Qubit()) {//only necessary to match the number of qubits for the adder
                 let carries = [ancillas[nQubits], testCarry];
-                for (idxBit in 0..nQubits-1){
+                for idxBit in 0..nQubits-1 {
                     (Controlled AddInteger)([xsLE![idxBit]], (LittleEndian(ysLE! + ysCarry), LittleEndian(outputsLE! + [carries[0]]), carries[1]));
                     CNOT(outputsLE![0], ms[idxBit]);
                     (Controlled AddConstant)([ms[idxBit]], (modulus, LittleEndian(outputsLE! + carries)));
@@ -1311,7 +1311,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     /// added to the look-up register, it clears the lower k bits.
     operation WriteLowBitClearingMultiple(index : BigInt, bitLength : Int, modulus : BigInt, register : LittleEndian) : Unit {
         body (...){
-            (Controlled WriteLowBitClearingMultiple)(new Qubit[0], (index, bitLength, modulus, register));
+            (Controlled WriteLowBitClearingMultiple)([], (index, bitLength, modulus, register));
         }
         controlled (controls, ...){
             let newIndex = 2L^bitLength - index;
@@ -1370,19 +1370,19 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 AssertEnoughQubits(nSelfOutputs, "Montgomery multiplication output: ", blankOutputs::register!);
                 let ms = ancillas[0 .. nQubits - 1];
                 let carry = ancillas[nQubits];
-                using (ysCarry = Qubit[1]){//only necessary to match the number of qubits for the adder
+                use ysCarry = Qubit[1] {//only necessary to match the number of qubits for the adder
                     let nWindows = nQubits / windowSize + 1 - BoolArrayAsInt([nQubits % windowSize == 0]);
-                    for (idxWindow in 0 .. nWindows - 1){
+                    for idxWindow in 0 .. nWindows - 1 {
                         let currentWindowSize = MinI(windowSize, nQubits - idxWindow * windowSize);// max possible window size
                         // Allocates extra qubits for carries, which are cleared with every window
-                        using (outputAncillas = Qubit[currentWindowSize]){
+                        use outputAncillas = Qubit[currentWindowSize] {
                             // Bookkeeping of ancilla
                             let outputs = outputsLE! + [carry] + outputAncillas;
                             let smallOutputs = outputsLE! + [carry] + outputAncillas[0.. currentWindowSize - 2];
                             let lastOutput = outputAncillas[currentWindowSize - 1];
                             // This loop does a naive multiplication of windowSize bits of x
                             // and the entire integer y, adding the result to the output register
-                            for (idxWindowBit in 0 .. currentWindowSize - 1){
+                            for idxWindowBit in 0 .. currentWindowSize - 1 {
                                 // get n+1 bits 
                                 let roundOutputs = LittleEndian(outputs[idxWindowBit .. idxWindowBit + nQubits]);
                                 (Controlled AddInteger)(
@@ -1405,7 +1405,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                             // Adds that register to the outputs to clear the low bits
                             // Possible future improvement: an "EqualLookup" that takes a function, rather than
                             // an array
-                            using (modulusQubits = Qubit[nQubits + currentWindowSize]){
+                            use modulusQubits = Qubit[nQubits + currentWindowSize] {
                                 let modulusMultiple = LittleEndian(modulusQubits);
                                 let bigIntSequence = Microsoft.Quantum.Arrays.SequenceL(0L, 2L^currentWindowSize - 1L);
                                 EqualLookup(bigIntSequence, WriteLowBitClearingMultiple(_, currentWindowSize, modulus, modulusMultiple), address);
@@ -1470,13 +1470,13 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     ///   https : //eprint.iacr.org/2017/598
     operation ModularMulMontgomeryFormGeneric(copyop : ((MontModInt) => Unit is Ctl + Adj), xs : MontModInt, ys : MontModInt) : Unit {
         body (...) {
-            (Controlled ModularMulMontgomeryFormGeneric)(new Qubit[0], (copyop, xs, ys));
+            (Controlled ModularMulMontgomeryFormGeneric)([], (copyop, xs, ys));
         }
         controlled (controls, ...){
             let modulus = xs::modulus;
             let nQubits=Length(xs::register!);
             let (nAncilla, nOutputs) = AncillaCountModularMulMontgomeryForm(nQubits);
-            using((ancillas, outputs) = (Qubit[nAncilla], Qubit[nOutputs])){
+            use (ancillas, outputs) = (Qubit[nAncilla], Qubit[nOutputs]) {
                 let innerzs = MontModInt(modulus, LittleEndian(outputs));       
                 ModularMulMontgomeryFormOpen(xs, ys, ancillas, innerzs);
                 /// Since we reverse the main body of the circuit, this is the only
@@ -1558,13 +1558,13 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     ///   https : //eprint.iacr.org/2017/598
     operation ModularMulMontgomeryFormWindowedGeneric(copyop : ((MontModInt) => Unit is Ctl + Adj), xs : MontModInt, ys : MontModInt) : Unit {
         body (...) {
-            (Controlled ModularMulMontgomeryFormWindowedGeneric)(new Qubit[0], (copyop, xs, ys));
+            (Controlled ModularMulMontgomeryFormWindowedGeneric)([], (copyop, xs, ys));
         }
         controlled (controls, ...){
             let modulus = xs::modulus;
             let nQubits=Length(xs::register!);
             let (nAncilla, nOutputs) = AncillaCountModularMulMontgomeryForm(nQubits);
-            using((ancillas, outputs) = (Qubit[nAncilla], Qubit[nOutputs])){
+            use (ancillas, outputs) = (Qubit[nAncilla], Qubit[nOutputs]) {
                 let innerzs = MontModInt(modulus, LittleEndian(outputs));
                 let windowSize = OptimalMultiplicationWindowSize(nQubits);
                 ModularMulMontgomeryFormWindowedOpen(windowSize, xs, ys, ancillas, innerzs);                    
@@ -1623,16 +1623,16 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
             // Thus, if the number of 1 bits in the constant is less than 9/10 * number of bits
             // Then it is more cost effective to add uncontrolled
             if (9 * nQubits < 10 * numOneBits){
-                (Controlled MulByConstantMontgomeryFormOpen)(new Qubit[0], (constant, xs, ancillas, blankOutputs));
+                (Controlled MulByConstantMontgomeryFormOpen)([], (constant, xs, ancillas, blankOutputs));
             } else {
                 // Ancilla bookkeeping
                 let carries = ancillas[nQubits .. nQubits + 1];
                 let outputOneCarry = LittleEndian(blankOutputs::register! + [carries[0]]);
                 let outputTwoCarries = LittleEndian(blankOutputs::register!+carries);
                 // The input requires an extra qubit to match the output
-                using (xCarry = Qubit[1]){
+                use xCarry = Qubit[1] {
                     let xsOneCarry = LittleEndian(xs::register! + xCarry);
-                    for (idx in 0..nQubits - 1){
+                    for idx in 0..nQubits - 1 {
                         //Small constants will produce small arrays
                         //This simulates leading zeros
                         if (Length(constantArray) > idx){
@@ -1665,9 +1665,9 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
             // The input requires an extra qubit to match the output
             // This is only used in the second if, but it would be 
             // difficult to conditionally allocate a qubit.
-            using (xCarry = Qubit[1]){
+            use xCarry = Qubit[1] {
                 let xsOneCarry = LittleEndian(xs::register! + xCarry);
-                for (idx in 0..nQubits - 1){
+                for idx in 0..nQubits - 1 {
                     // A single controlled addition by a constant uses 9n+o(n) Toffoli gates
                     // A single controlled addition of two quantum registers uses 12n+o(n) Toffoli gates
                     // This chooses the cheaper option based on the Hamming weight
@@ -1737,12 +1737,12 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     ///   https : //eprint.iacr.org/2017/598
     operation MulByConstantMontgomeryFormGeneric(copyop : (MontModInt=>Unit is Ctl + Adj), constant:BigInt, xs:MontModInt):Unit {
         body (...){
-            (Controlled MulByConstantMontgomeryFormGeneric)(new Qubit[0], (copyop, constant, xs));
+            (Controlled MulByConstantMontgomeryFormGeneric)([], (copyop, constant, xs));
         }
         controlled (controls,...){
             let nQubits = Length(xs::register!);
             let (nMulAncilla, nMulOutputs) = AncillaCountConstantMulMontgomeryForm(nQubits);
-            using ((ancillas, outputs) = (Qubit[nMulAncilla], Qubit[nMulOutputs])){
+            use (ancillas, outputs) = (Qubit[nMulAncilla], Qubit[nMulOutputs]) {
                 let productMontModInt = MontModInt(xs::modulus, LittleEndian(outputs));
                 MulByConstantMontgomeryFormOpen(constant, xs, ancillas, productMontModInt);
                 (Controlled copyop)(controls, (productMontModInt));
@@ -1788,9 +1788,9 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
             AssertEnoughQubits(nSelfOutput, "Montgomery square output: ", blankOutputs::register!);
             AssertEnoughQubits(nSelfAncilla, "Montgomery square ancilla: ", ancillas);
             let ms = ancillas[0 .. nQubits - 1];
-            using ((xControl, xsCarry, testCarry) = (Qubit(), Qubit[1], Qubit())){//only necessary to match the number of qubits for the TTK adder
+            use (xControl, xsCarry, testCarry) = (Qubit(), Qubit[1], Qubit()) {//only necessary to match the number of qubits for the TTK adder
                 let carries = [ancillas[nQubits], testCarry];
-                for (idxBit in 0..nQubits-1){
+                for idxBit in 0..nQubits-1 {
                     CNOT((xs::register)![idxBit], xControl);
                     (Controlled AddInteger)([xControl], (LittleEndian(xsLE! + xsCarry), LittleEndian(outputsLE! + [carries[0]]), carries[1]));
                     CNOT((xs::register)![idxBit], xControl);
@@ -1867,20 +1867,20 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 AssertEnoughQubits(nSelfAncilla, "Montgomery square ancilla: ", ancillas);
                 let ms = ancillas[0 .. nQubits - 1];
                 let carry = ancillas[nQubits];
-                using (xsCarry = Qubit[1]){//only necessary to match the number of qubits for the adder
+                use xsCarry = Qubit[1] {//only necessary to match the number of qubits for the adder
                     let nWindows = nQubits / windowSize + 1 - BoolArrayAsInt([nQubits % windowSize == 0]);
-                    for (idxWindow in 0 .. nWindows - 1){
+                    for idxWindow in 0 .. nWindows - 1 {
                         let currentWindowSize = MinI(windowSize, nQubits - idxWindow * windowSize);// max possible window size
                         // Allocates extra qubits for carries, which are cleared with every window
-                        using (outputAncillas = Qubit[currentWindowSize]){
+                        use outputAncillas = Qubit[currentWindowSize] {
                             // Bookkeeping of ancilla
                             let outputs = outputsLE! + [carry] + outputAncillas;
                             let smallOutputs = outputsLE! + [carry] + outputAncillas[0.. currentWindowSize - 2];
                             let lastOutput = outputAncillas[currentWindowSize - 1];
                             // This loop does a naive multiplication of windowSize bits of x
                             // and the entire integer y, adding the result to the output register
-                            using (xControl = Qubit()){
-                                for (idxWindowBit in 0 .. currentWindowSize - 1){
+                            use xControl = Qubit() {
+                                for idxWindowBit in 0 .. currentWindowSize - 1 {
                                     // get n+1 bits 
                                     CNOT(xsLE![idxWindowBit + idxWindow * windowSize], xControl);
                                     let roundOutputs = LittleEndian(outputs[idxWindowBit .. idxWindowBit + nQubits]);
@@ -1907,7 +1907,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                             // Adds that register to the outputs to clear the low bits
                             // Possible future improvement: an "EqualLookup" that takes a function, rather than
                             // an array
-                            using (modulusQubits = Qubit[nQubits + currentWindowSize]){
+                            use modulusQubits = Qubit[nQubits + currentWindowSize] {
                                 let modulusMultiple = LittleEndian(modulusQubits);
                                 let bigIntSequence = Microsoft.Quantum.Arrays.SequenceL(0L, 2L^currentWindowSize - 1L);
                                 EqualLookup(bigIntSequence, WriteLowBitClearingMultiple(_, currentWindowSize, modulus, modulusMultiple), address);
@@ -1969,13 +1969,13 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     ///   https : //eprint.iacr.org/2017/598
     operation ModularSquMontgomeryFormGeneric (copyop : ((MontModInt) => Unit is Ctl + Adj), xs : MontModInt) : Unit {
         body (...) {
-            (Controlled ModularSquMontgomeryFormGeneric)(new Qubit[0], (copyop, xs));
+            (Controlled ModularSquMontgomeryFormGeneric)([], (copyop, xs));
         }
         controlled (controls, ...){
             let modulus = xs::modulus;
             let nQubits=Length(xs::register!);
             let (nAncillas, nOutputs) = AncillaCountModularSquMontgomeryForm(nQubits);
-            using((ancillas, outputQubits) = (Qubit[nAncillas], Qubit[nOutputs])){
+            use (ancillas, outputQubits) = (Qubit[nAncillas], Qubit[nOutputs]) {
                 let innerzs = MontModInt(modulus, LittleEndian(outputQubits));
                 ModularSquMontgomeryFormOpen(xs, ancillas, innerzs);
                 /// Since we reverse the main body of the circuit, this is the only
@@ -2011,7 +2011,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     ///   https : //eprint.iacr.org/2017/598
     operation ModularSquMontgomeryFormWindowedGeneric (copyop : ((MontModInt) => Unit is Ctl + Adj), xs : MontModInt) : Unit {
         body (...) {
-            (Controlled ModularSquMontgomeryFormWindowedGeneric)(new Qubit[0], (copyop, xs));
+            (Controlled ModularSquMontgomeryFormWindowedGeneric)([], (copyop, xs));
         }
         controlled (controls, ...){
             //DumpLittleEndian(xs::register, "Input:");
@@ -2022,7 +2022,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
                 (Controlled ModularSquMontgomeryFormGeneric)(controls, (copyop, xs));
             } else {
                 let (nAncilla, nOutputs) = AncillaCountModularSquMontgomeryForm(nQubits);
-                using((ancillas, outputs) = (Qubit[nAncilla], Qubit[nOutputs])){
+                use (ancillas, outputs) = (Qubit[nAncilla], Qubit[nOutputs]) {
                     let innerzs = MontModInt(modulus, LittleEndian(outputs));
                     ModularSquMontgomeryFormWindowedOpen(windowSize, xs, ancillas, innerzs);
                     /// Since we reverse the main body of the circuit, this is the only
@@ -2069,13 +2069,13 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     ///   https : //doi.org/10.1109/12.403725
     operation _MontBitGCDRound(indexm : Int, us : LittleEndian, vs : LittleEndian, rs : LittleEndian, ss : LittleEndian, ms : Qubit[]) : Unit {
         body(...){
-            (Controlled _MontBitGCDRound)(new Qubit[0], (indexm, us, vs, rs, ss, ms));
+            (Controlled _MontBitGCDRound)([], (indexm, us, vs, rs, ss, ms));
         }
         controlled(controls, ...){
             if (Length(controls) > 1 ){
                 Message($"Warning: GCD round called with {Length(controls)} controls");
             }
-            using ((carry, aQubit, bQubit)=(Qubit(), Qubit(), Qubit())){
+            use (carry, aQubit, bQubit)=(Qubit(), Qubit(), Qubit()) {
                 //carry is the qubit in figure 9 between v and s
                 //aqubit is the bottom qubit in figure 9, between r and m_i
                 //bqubit is the top qubit in figure 9, between r and m_i
@@ -2193,7 +2193,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
             //Set up the counter
             let counter = QubitsAsCounter(counterQubits);
             counter::Prepare();
-            using ((uQubits, rQubits, sQubits)=(Qubit[nQubits], Qubit[nQubits], Qubit[nQubits+1])){
+            use (uQubits, rQubits, sQubits)=(Qubit[nQubits], Qubit[nQubits], Qubit[nQubits+1]) {
                 let vsLE = vs::register;
                 let us = LittleEndian(uQubits);
                 let rs = LittleEndian(rQubits + [rCarry]);
@@ -2266,7 +2266,7 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
             _MontBitGCDWithAncillaInner(NoOp<Int>(_), xs, register);
             CopyMontModInt(xs,blankOutputs);
             //Corrects the pseudo-inverse
-            using (secondCounterQubits = Qubit[logn + 1]){
+            use secondCounterQubits = Qubit[logn + 1] {
                 let secondCounter = QubitsAsCounter(secondCounterQubits);
                 secondCounter::Prepare();
                 let Decrementer = DummyIntegerWrapper((Adjoint counter::Increment), (), _);
@@ -2332,13 +2332,13 @@ namespace Microsoft.Quantum.Crypto.ModularArithmetic {
     /// with non-commutative operations.
     operation InvertBitShiftConstantModulusGeneric(copyop : (MontModInt=> Unit is Ctl + Adj), doubleop : (Int=>Unit is Ctl + Adj), xs : MontModInt) : Unit {
         body (...) {
-            (Controlled InvertBitShiftConstantModulusGeneric)(new Qubit[0], (copyop, doubleop, xs));
+            (Controlled InvertBitShiftConstantModulusGeneric)([], (copyop, doubleop, xs));
         }
         controlled (controls, ...){
             let modulus = xs::modulus;
             let nQubits=Length(xs::register!);
             let logn = BitSizeI(nQubits);
-            using (register =Qubit[2 * nQubits + logn + 2]){
+            use register =Qubit[2 * nQubits + logn + 2] {
                 
                 //Not controlled because it will be reversed immediately
                  _MontBitGCDWithAncillaInner(doubleop(_), xs, register);

--- a/MicrosoftQuantumCrypto/Tests/ArithmeticTests.qs
+++ b/MicrosoftQuantumCrypto/Tests/ArithmeticTests.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Crypto.Tests{
         control2 : Bool,
         inputTarget : Bool
     ) : Unit {
-        using ((qControl1, qControl2, qTarget) = (Qubit(), Qubit(), Qubit())){
+        use (qControl1, qControl2, qTarget) = (Qubit(), Qubit(), Qubit()) {
             let expected = Xor(control1 and control2, inputTarget);
 
             mutable mControl1 = false;
@@ -51,9 +51,9 @@ namespace Microsoft.Quantum.Crypto.Tests{
         mutable control1 = false;
         mutable control2 = false;
         mutable target = false;
-        for (idx1 in 0..1){
-           for (idx2 in 0..1){
-                for (idx3 in 0..1){
+        for idx1 in 0..1 {
+           for idx2 in 0..1 {
+                for idx3 in 0..1 {
 
                     set target = not target;
                 }
@@ -74,7 +74,7 @@ namespace Microsoft.Quantum.Crypto.Tests{
         testValue : BigInt,
         nQubits : Int
     ) : Unit {
-        using ((valueQubits, output) = (Qubit[nQubits], Qubit())){
+        use (valueQubits, output) = (Qubit[nQubits], Qubit()) {
             let expected = (2L^nQubits - 1L == testValue) ? One | Zero;
             let qValue = LittleEndian(valueQubits);
             mutable actualValue = 0L;
@@ -92,8 +92,8 @@ namespace Microsoft.Quantum.Crypto.Tests{
             Reset(output);
             Fact(actualOutput == expected, $"On input {testValue}, expected {expected}, got {actualOutput}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                      //Write to qubit registers
                      ApplyXorInPlaceL(testValue, qValue);
 
@@ -132,8 +132,8 @@ namespace Microsoft.Quantum.Crypto.Tests{
     operation CheckIfAllOnesReversibleTestHelper(
         OnesTest : ((Qubit[], Qubit) => Unit is Ctl + Adj),
         nQubits : Int) : Unit{
-        for (problemSize in 1 .. nQubits){
-            for (value in 0 .. 2^(problemSize - 1) - 1){
+        for problemSize in 1 .. nQubits {
+            for value in 0 .. 2^(problemSize - 1) - 1 {
                 CheckIfAllOnesTestHelper(OnesTest, IntAsBigInt(value), nQubits);
             }
         }
@@ -151,7 +151,7 @@ operation EqualLookupTestHelper(
     addressSize : Int
 ) : Unit {
     body (...) {
-        using ((addressQubits, outputQubits) = (Qubit[addressSize], Qubit[addressSize])){
+        use (addressQubits, outputQubits) = (Qubit[addressSize], Qubit[addressSize]) {
             // Bookkeeping and qubit allocation
             let qAddress = LittleEndian(addressQubits);
             let qValue = LittleEndian(outputQubits);
@@ -170,8 +170,8 @@ operation EqualLookupTestHelper(
             set readAddress = MeasureBigInteger(qAddress);
             Fact(readAddress == IntAsBigInt(address), $"Address: Expected {address}, got {readAddress}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                     //write to qubit registers
                     ApplyXorInPlaceL(IntAsBigInt(address), qAddress);
 
@@ -211,7 +211,7 @@ operation EqualLookUpExhaustiveTestHelper(
     addressSize : Int
 ) : Unit {
     mutable bigTable = [0L];
-    for (i in 1 .. 2 ^ addressSize - 1){
+    for i in 1 .. 2 ^ addressSize - 1 {
         set bigTable = bigTable + [IntAsBigInt(i)];
     }
     let address = Microsoft.Quantum.Random.DrawRandomInt(0, 2 ^ addressSize - 1);
@@ -255,7 +255,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 
  operation IntegerAdderTestHelper( IntegerAdderToTest : ( (LittleEndian, LittleEndian, Qubit) => Unit is Ctl + Adj), summand1 : BigInt, summand2 : BigInt, numberOfQubits : Int ) : Unit {
         body (...) {
-            using (register = Qubit[2*numberOfQubits + 1]) {
+            use register = Qubit[2*numberOfQubits + 1] {
 				// Bookkeeping and qubit allocation
                 mutable actual_carry = 0L;
                 mutable actual1 = 0L;
@@ -308,8 +308,8 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
                 set measured_carry = MResetZ(carry);
                 Fact(difference_carry == ResultAsBool(measured_carry), $"Difference Carry: Expected {difference_carry}, got {measured_carry}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
 						// Write to qubit registers
                         ApplyXorInPlaceL(summand1, summand1LE);
                         ApplyXorInPlaceL(summand2, summand2LE);
@@ -396,8 +396,8 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
  
     operation IntegerAdderExhaustiveTestHelper (IntegerAdderToTest : ( (LittleEndian, LittleEndian, Qubit) => Unit is Ctl + Adj), numberOfQubits : Int) : Unit {
-        for( summand1 in 0 .. 2^numberOfQubits - 1 ) {
-            for( summand2 in 0 .. 2^numberOfQubits - 1 ) {
+        for  summand1 in 0 .. 2^numberOfQubits - 1  {
+            for  summand2 in 0 .. 2^numberOfQubits - 1  {
                 IntegerAdderTestHelper(IntegerAdderToTest, IntAsBigInt(summand1), IntAsBigInt(summand2), numberOfQubits);
             }
         }
@@ -410,7 +410,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 	operation CarryLookAheadAdderExhaustiveReversibleTest (): Unit {
 		let maxNumberOfQubits = 8;
 		let minNumberOfQubits = 1;
-		for (numberOfQubits in minNumberOfQubits .. maxNumberOfQubits){
+		for numberOfQubits in minNumberOfQubits .. maxNumberOfQubits {
 			IntegerAdderExhaustiveTestHelper(CarryLookAheadAdder,numberOfQubits);
 		}
 	}
@@ -422,7 +422,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     operation CDKMGAdderExhaustiveReversibleTest (): Unit {
         let maxNumberOfQubits = 8;
         let minNumberOfQubits = 1;
-        for (numberOfQubits in minNumberOfQubits .. maxNumberOfQubits){
+        for numberOfQubits in minNumberOfQubits .. maxNumberOfQubits {
             IntegerAdderExhaustiveTestHelper(CDKMGAdder,numberOfQubits);
         }
     }
@@ -434,7 +434,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
       operation AdderExhaustiveReversibleTest (): Unit {
         let maxNumberOfQubits = 8;
         let minNumberOfQubits = 1;
-        for (numberOfQubits in minNumberOfQubits .. maxNumberOfQubits){
+        for numberOfQubits in minNumberOfQubits .. maxNumberOfQubits {
             IntegerAdderExhaustiveTestHelper(AddInteger,numberOfQubits);
         }
     }
@@ -460,7 +460,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 	///		* RippleCarryAdderNoCarryTTK
 	///		* CarryLookAheadAdderNoCarry
     operation IntegerAdderNoCarryTestHelper( IntegerAdderToTest : ( (LittleEndian, LittleEndian) => Unit is Ctl), summand1 : BigInt, summand2 : BigInt, numberOfQubits : Int ) : Unit {
-        using (register = Qubit[2*numberOfQubits]) {
+        use register = Qubit[2*numberOfQubits] {
 			// Bookkeeping and qubit allocation
             mutable actual1 = 0L;
             mutable actual2 = 0L;
@@ -485,8 +485,8 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
             Fact(expected== actual2, $"Expected {expected}, got {actual2}");
             let expected_carry = (sum / IntAsBigInt(2^numberOfQubits));
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
 					//Write to qubit regiters
                     ApplyXorInPlaceL(summand1, summand1LE);
                     ApplyXorInPlaceL(summand2, summand2LE);
@@ -524,8 +524,8 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
     operation IntegerAdderNoCarryExhaustiveTestHelper (IntegerAdderToTest : ( (LittleEndian, LittleEndian) => Unit is Ctl), numberOfQubits : Int) : Unit {
-        for( summand1 in 0 .. 2^numberOfQubits - 1 ) {
-            for( summand2 in 0 .. 2^numberOfQubits - 1 ) {
+        for  summand1 in 0 .. 2^numberOfQubits - 1  {
+            for  summand2 in 0 .. 2^numberOfQubits - 1  {
                 IntegerAdderNoCarryTestHelper(IntegerAdderToTest, IntAsBigInt(summand1), IntAsBigInt(summand2), numberOfQubits);
             }
         }
@@ -544,7 +544,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
     operation RippleCarryAdderNoCarryTTKExhaustiveReversibleTest () : Unit {
-        for (numberOfQubits in 1..6) {
+        for numberOfQubits in 1..6 {
             IntegerAdderNoCarryExhaustiveTestHelper (RippleCarryAdderNoCarryTTK, numberOfQubits);
         }
     }
@@ -555,7 +555,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 	operation CarryLookAheadAdderNoCarryExhaustiveReversibleTest (): Unit {
 		let maxNumberOfQubits = 8;
 		let minNumberOfQubits = 1;
-		for (numberOfQubits in minNumberOfQubits .. maxNumberOfQubits){
+		for numberOfQubits in minNumberOfQubits .. maxNumberOfQubits {
 			IntegerAdderNoCarryExhaustiveTestHelper(CarryLookAheadAdderNoCarry,numberOfQubits);
 		}
 	}
@@ -567,7 +567,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     operation CDKMGAdderNoCarryExhaustiveReversibleTest (): Unit {
         let maxNumberOfQubits = 8;
         let minNumberOfQubits = 1;
-        for (numberOfQubits in minNumberOfQubits .. maxNumberOfQubits){
+        for numberOfQubits in minNumberOfQubits .. maxNumberOfQubits {
             IntegerAdderNoCarryExhaustiveTestHelper(CDKMGAdderNoCarry,numberOfQubits);
         }
     }
@@ -579,7 +579,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     operation AdderNoCarryExhaustiveReversibleTest (): Unit {
         let maxNumberOfQubits = 8;
         let minNumberOfQubits = 1;
-        for (numberOfQubits in minNumberOfQubits .. maxNumberOfQubits){
+        for numberOfQubits in minNumberOfQubits .. maxNumberOfQubits {
             IntegerAdderNoCarryExhaustiveTestHelper(AddIntegerNoCarry ,numberOfQubits);
         }
     }
@@ -605,7 +605,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 	///		* _AddConstantLowT
 	operation AddConstantTestHelper(Adder:((BigInt,LittleEndian)=>Unit is Ctl), constant : BigInt, integer : BigInt, numberOfQubits : Int ) : Unit {
         body (...) {
-            using (register = Qubit[numberOfQubits + 2]) {
+            use register = Qubit[numberOfQubits + 2] {
 				// Bookkeeping and qubit allocation
                 mutable actual = 0L;
                 let integerLE = LittleEndian(register[0 .. numberOfQubits - 1]);
@@ -623,8 +623,8 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
                 set actual = MeasureBigInteger(integerLE);
                 Fact(expected== actual, $"Expected {expected}, got {actual}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
 						// Write to qubit register
                         ApplyXorInPlaceL(integer, integerLE);
 
@@ -658,8 +658,8 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 
     operation AddConstantExhaustiveTestHelper (Adder:((BigInt,LittleEndian)=>Unit is Ctl),numberOfQubits : Int) : Unit {
         body (...) {
-            for( constant in 0 .. 2^numberOfQubits - 1 ) {
-                for( integer in 0 .. 2^numberOfQubits - 1 ) {
+            for  constant in 0 .. 2^numberOfQubits - 1  {
+                for  integer in 0 .. 2^numberOfQubits - 1  {
                     AddConstantTestHelper(Adder,IntAsBigInt(constant), IntAsBigInt(integer), numberOfQubits);
                 }
             }
@@ -718,7 +718,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
         body (...) {
 			let maxNumberOfQubits = 8;
 			let minNumberOfQubits = 1;
-			for (numberOfQubits in minNumberOfQubits .. maxNumberOfQubits){
+			for numberOfQubits in minNumberOfQubits .. maxNumberOfQubits {
 				AddConstantExhaustiveTestHelper (CarryLookAheadAddConstant,numberOfQubits);
 			}
         }
@@ -737,7 +737,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
         body (...) {
             let maxNumberOfQubits = 8;
             let minNumberOfQubits = 1;
-            for (numberOfQubits in minNumberOfQubits .. maxNumberOfQubits){
+            for numberOfQubits in minNumberOfQubits .. maxNumberOfQubits {
                 AddConstantExhaustiveTestHelper (CDKMGAddConstant,numberOfQubits);
             }
         }
@@ -763,7 +763,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 	///		* GreaterThanLookAhead
 	///		* GreaterThan
     operation GreaterThanTestHelper(Comparator:((LittleEndian,LittleEndian,Qubit)=>Unit is Ctl), integer1 : BigInt, integer2 : BigInt, numberOfQubits : Int ) : Unit {
-        using (register = Qubit[2*numberOfQubits+1]) {
+        use register = Qubit[2*numberOfQubits+1] {
 			// Bookkeeping and qubit allocation
             mutable actual1 = 0L;
             mutable actual2 = 0L;
@@ -792,8 +792,8 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 			Reset(result);
             EqualityFactB((gt == actualr), true, $"Expected {gt}, got {actualr}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
 					// Write to qubit register
                     ApplyXorInPlaceL(integer1, integer1LE);
                     ApplyXorInPlaceL(integer2, integer2LE);
@@ -835,9 +835,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
     operation GreaterThanExhaustiveReversibleTest () : Unit {
-        for (numberOfQubits in 1..5) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..5 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     GreaterThanTestHelper(GreaterThanWrapper ,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -845,9 +845,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
 	operation GreaterThanLookAheadExhaustiveTest () : Unit {
-        for (numberOfQubits in 1..5) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..5 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     GreaterThanTestHelper(GreaterThanLookAhead,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -855,9 +855,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
     operation GreaterThanLookAheadExhaustiveReversibleTest () : Unit {
-        for (numberOfQubits in 1..7) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..7 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     GreaterThanTestHelper(GreaterThanLookAhead,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -865,9 +865,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
     operation GreaterThanCDKMGExhaustiveReversibleTest () : Unit {
-        for (numberOfQubits in 1..7) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..7 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     GreaterThanTestHelper(CKDMGGreaterThan, IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -893,7 +893,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 	/// This can test:
 	///		* GreaterThanConstantLookAhead
 	operation GreaterThanConstantTestHelper(Comparator:((BigInt,LittleEndian,Qubit)=>Unit is Ctl), constant : BigInt, integer : BigInt, numberOfQubits : Int ) : Unit {
-        using (register = Qubit[numberOfQubits+1]) {
+        use register = Qubit[numberOfQubits+1] {
             mutable actual = 0L;
             mutable actualr = Zero;
             mutable gt = Zero;
@@ -911,8 +911,8 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
             EqualityFactB((gt == actualr), true, $"Expected {gt}, got {actualr}");
 
             Reset(result);
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
 				    ApplyXorInPlaceL(integer, integerLE);
                     (Controlled Comparator) (controls, (constant,integerLE, result));
 
@@ -937,9 +937,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
         }
     }
 	operation GreaterThanConstantLookAheadExhaustiveReversibleTest () : Unit {
-        for (numberOfQubits in 1..7) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..7 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     GreaterThanConstantTestHelper(GreaterThanConstantLookAhead,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -947,9 +947,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
 	operation GreaterThanConstantLookAheadExhaustiveTest () : Unit {
-        for (numberOfQubits in 1..5) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..5 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     GreaterThanConstantTestHelper(GreaterThanConstantLookAhead,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -957,9 +957,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
     operation GreaterThanConstantExhaustiveReversibleTest () : Unit {
-        for (numberOfQubits in 1..7) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..7 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     GreaterThanConstantTestHelper(GreaterThanConstant,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -967,9 +967,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
     operation GreaterThanConstantExhaustiveTest () : Unit {
-        for (numberOfQubits in 1..5) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..5 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     GreaterThanConstantTestHelper(GreaterThanConstant,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -995,7 +995,7 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 	/// This can test:
 	///		* LessThanConstantLookAhead
 	operation LessThanConstantTestHelper(Comparator:((BigInt,LittleEndian,Qubit)=>Unit is Ctl), constant : BigInt, integer : BigInt, numberOfQubits : Int ) : Unit {
-        using (register = Qubit[numberOfQubits+1]) {
+        use register = Qubit[numberOfQubits+1] {
 			// Bookkeeping and qubit allocation
             mutable actual = 0L;
             mutable actualr = Zero;
@@ -1019,8 +1019,8 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
 			Reset(result);
             EqualityFactB((gt == actualr), true, $"Expected {gt}, got {actualr}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
 					//Write to qubit registers
 				    ApplyXorInPlaceL(integer, integerLE);
 
@@ -1055,9 +1055,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
         }
     }
 	operation LessThanConstantLookAheadExhaustiveReversibleTest () : Unit {
-        for (numberOfQubits in 1..7) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..7 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     LessThanConstantTestHelper(LessThanConstantLookAhead,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -1065,9 +1065,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
 	operation LessThanConstantLookAheadExhaustiveTest () : Unit {
-        for (numberOfQubits in 1..5) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..5 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     LessThanConstantTestHelper(LessThanConstantLookAhead,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -1075,9 +1075,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
     operation LessThanConstantExhaustiveReversibleTest () : Unit {
-        for (numberOfQubits in 1..7) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..7 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     LessThanConstantTestHelper(LessThanConstant,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }
@@ -1085,9 +1085,9 @@ operation EqualLookupExhaustiveReversibleTest() : Unit {
     }
 
     operation LessThanConstantExhaustiveTest () : Unit {
-        for (numberOfQubits in 1..5) {
-            for (integer1 in 0..2^numberOfQubits-1) {
-                for (integer2 in 0..2^numberOfQubits-1) {
+        for numberOfQubits in 1..5 {
+            for integer1 in 0..2^numberOfQubits-1 {
+                for integer2 in 0..2^numberOfQubits-1 {
                     LessThanConstantTestHelper(LessThanConstant,IntAsBigInt(integer1), IntAsBigInt(integer2), numberOfQubits);
                 }
             }

--- a/MicrosoftQuantumCrypto/Tests/DebugHelpers.qs
+++ b/MicrosoftQuantumCrypto/Tests/DebugHelpers.qs
@@ -97,7 +97,7 @@ namespace Microsoft.Quantum.ModularArithmetic.DebugHelpers
 
 
     function PrintClassicalECPointArray(points: ECPointMontgomeryXZClassical[] ) : Unit {
-        for (idx in 0..Length(points) - 1){
+        for idx in 0..Length(points) - 1 {
             Message($"Point {idx}:" + ECPointMontgomeryXZClassicalAsString(points[idx]));
         }
     }
@@ -106,7 +106,7 @@ namespace Microsoft.Quantum.ModularArithmetic.DebugHelpers
     operation DumpECPointArray(points : ECPointMontgomeryXZ[], message : String) : Unit {
         body (...){
             Message(message);
-            for (idx in 0.. Length(points) - 1){
+            for idx in 0.. Length(points) - 1 {
                 DumpECPoint(points[idx], $"Point {idx}:");
             }
         }
@@ -185,7 +185,7 @@ namespace Microsoft.Quantum.ModularArithmetic.DebugHelpers
     operation DumpQubits(qubits:Qubit[],message:String):Unit {
         body(...){
             mutable newmessage = message;
-            for (idx in 0..Length(qubits)-1){
+            for idx in 0..Length(qubits)-1 {
                 if (ResultAsBool(M(qubits[idx]))){
                     set newmessage = newmessage + "1";
                 } else {

--- a/MicrosoftQuantumCrypto/Tests/EllipticCurveTests.qs
+++ b/MicrosoftQuantumCrypto/Tests/EllipticCurveTests.qs
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nQubits : Int) : Unit {
       body (...) {
           // Bookkeeping and qubit allocation
-            using (register = Qubit[4 * nQubits]) {
+            use register = Qubit[4 * nQubits] {
                 // Write to qubit registers
                 mutable qpoint1 = ClassicalECPointToQuantum(point1, register[0..2 * nQubits-1]);
                 mutable qpoint2 = ClassicalECPointToQuantum(point2, register[2 * nQubits..4 * nQubits-1]);
@@ -52,8 +52,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 mutable actualp2 = MeasureECPoint(qpoint2);
                 Fact(expected::x == actualp2::x and expected::y == actualp2::y and expected::z == actualp2::z, $"Output : Expected {expected!}, got {actualp2!}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         //Write to qubit registers
                         set qpoint1 = ClassicalECPointToQuantum(point1, register[0..2 * nQubits-1]);
                         set qpoint2 = ClassicalECPointToQuantum(point2, register[2 * nQubits..4 * nQubits-1]);
@@ -113,14 +113,14 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 [4099, 4111, 4127, 4129, 4133, 4139, 4153, 4157, 4159, 4177, 4201, 4211, 4217, 4219, 4229, 4231, 4241, 4243, 4253, 4259, 4261, 4271, 4273, 4283, 4289, 4297, 4327, 4337, 4339, 4349, 4357, 4363, 4373, 4391, 4397, 4409, 4421, 4423, 4441, 4447, 4451, 4457, 4463, 4481, 4483, 4493, 4507, 4513, 4517, 4519, 4523, 4547, 4549, 4561, 4567, 4583, 4591, 4597, 4603, 4621, 4637, 4639, 4643, 4649, 4651, 4657, 4663, 4673, 4679, 4691, 4703, 4721, 4723, 4729, 4733, 4751, 4759, 4783, 4787, 4789, 4793, 4799, 4801, 4813, 4817, 4831, 4861, 4871, 4877, 4889, 4903, 4909, 4919, 4931, 4933, 4937, 4943, 4951, 4957, 4967, 4969, 4973, 4987, 4993, 4999, 5003, 5009, 5011, 5021, 5023, 5039, 5051, 5059, 5077, 5081, 5087, 5099, 5101, 5107, 5113, 5119, 5147, 5153, 5167, 5171, 5179, 5189, 5197, 5209, 5227, 5231, 5233, 5237, 5261, 5273, 5279, 5281, 5297, 5303, 5309, 5323, 5333, 5347, 5351, 5381, 5387, 5393, 5399, 5407, 5413, 5417, 5419, 5431, 5437, 5441, 5443, 5449, 5471, 5477, 5479, 5483, 5501, 5503, 5507, 5519, 5521, 5527, 5531, 5557, 5563, 5569, 5573, 5581, 5591, 5623, 5639, 5641, 5647, 5651, 5653, 5657, 5659, 5669, 5683, 5689, 5693, 5701, 5711, 5717, 5737, 5741, 5743, 5749, 5779, 5783, 5791, 5801, 5807, 5813, 5821, 5827, 5839, 5843, 5849, 5851, 5857, 5861, 5867, 5869, 5879, 5881, 5897, 5903, 5923, 5927, 5939, 5953, 5981, 5987, 6007, 6011, 6029, 6037, 6043, 6047, 6053, 6067, 6073, 6079, 6089, 6091, 6101, 6113, 6121, 6131, 6133, 6143, 6151, 6163, 6173, 6197, 6199, 6203, 6211, 6217, 6221, 6229, 6247, 6257, 6263, 6269, 6271, 6277, 6287, 6299, 6301, 6311, 6317, 6323, 6329, 6337, 6343, 6353, 6359, 6361, 6367, 6373, 6379, 6389, 6397, 6421, 6427, 6449, 6451, 6469, 6473, 6481, 6491, 6521, 6529, 6547, 6551, 6553, 6563, 6569, 6571, 6577, 6581, 6599, 6607, 6619, 6637, 6653, 6659, 6661, 6673, 6679, 6689, 6691, 6701, 6703, 6709, 6719, 6733, 6737, 6761, 6763, 6779, 6781, 6791, 6793, 6803, 6823, 6827, 6829, 6833, 6841, 6857, 6863, 6869, 6871, 6883, 6899, 6907, 6911, 6917, 6947, 6949, 6959, 6961, 6967, 6971, 6977, 6983, 6991, 6997, 7001, 7013, 7019, 7027, 7039, 7043, 7057, 7069, 7079, 7103, 7109, 7121, 7127, 7129, 7151, 7159, 7177, 7187, 7193, 7207, 7211, 7213, 7219, 7229, 7237, 7243, 7247, 7253, 7283, 7297, 7307, 7309, 7321, 7331, 7333, 7349, 7351, 7369, 7393, 7411, 7417, 7433, 7451, 7457, 7459, 7477, 7481, 7487, 7489, 7499, 7507, 7517, 7523, 7529, 7537, 7541, 7547, 7549, 7559, 7561, 7573, 7577, 7583, 7589, 7591, 7603, 7607, 7621, 7639, 7643, 7649, 7669, 7673, 7681, 7687, 7691, 7699, 7703, 7717, 7723, 7727, 7741, 7753, 7757, 7759, 7789, 7793, 7817, 7823, 7829, 7841, 7853, 7867, 7873, 7877, 7879, 7883, 7901, 7907, 7919]
             ];
             Fact(nQubits<=Length(primes), $"The helper does not have {nQubits}-bit primes");
-            for (modulus in primes[nQubits-1]) {
+            for modulus in primes[nQubits-1] {
                 if (modulus % 4 == 3){//necessary for lazy point validation
-                    for( curveround in 0 .. modulus - 1 ) {
+                    for  curveround in 0 .. modulus - 1  {
                         //pick random elliptic curves
                         let ca = DrawRandomInt(0,modulus - 1);
                         let cb = DrawRandomInt(0,modulus - 1);
                         if ((4 * ca^3+27 * cb^2) % modulus != 0) {
-                            for (pointround in 0 .. modulus - 1){
+                            for pointround in 0 .. modulus - 1 {
                                 //pick several points on the curve to test
                                  let p1x = DrawRandomInt(0,modulus - 1);
                                  let p1signint = DrawRandomInt(0,1);
@@ -194,7 +194,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     operation EllipticCurveDistinctClassicalPointAdditionTestHelper (PointAdder : ((ECPointClassical, ECPointMontgomeryForm)=>Unit is Ctl), point1 : ECPointClassical, point2 : ECPointClassical, nQubits : Int) : Unit {
       body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits]) {
+            use register = Qubit[2 * nQubits] {
 
                 //Write to qubit register
                 mutable qpoint = ClassicalECPointToQuantum(point2, register[0..2 * nQubits-1]);
@@ -209,8 +209,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 mutable actual = MeasureECPoint(qpoint);
                 Fact(expected::x == actual::x and expected::y == actual::y and expected::z == actual::z, $"Output : Expected {expected!}, got {actual!}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit register
                         set qpoint = ClassicalECPointToQuantum(point2, register[0..2 * nQubits-1]);
 
@@ -262,14 +262,14 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 [4099, 4111, 4127, 4129, 4133, 4139, 4153, 4157, 4159, 4177, 4201, 4211, 4217, 4219, 4229, 4231, 4241, 4243, 4253, 4259, 4261, 4271, 4273, 4283, 4289, 4297, 4327, 4337, 4339, 4349, 4357, 4363, 4373, 4391, 4397, 4409, 4421, 4423, 4441, 4447, 4451, 4457, 4463, 4481, 4483, 4493, 4507, 4513, 4517, 4519, 4523, 4547, 4549, 4561, 4567, 4583, 4591, 4597, 4603, 4621, 4637, 4639, 4643, 4649, 4651, 4657, 4663, 4673, 4679, 4691, 4703, 4721, 4723, 4729, 4733, 4751, 4759, 4783, 4787, 4789, 4793, 4799, 4801, 4813, 4817, 4831, 4861, 4871, 4877, 4889, 4903, 4909, 4919, 4931, 4933, 4937, 4943, 4951, 4957, 4967, 4969, 4973, 4987, 4993, 4999, 5003, 5009, 5011, 5021, 5023, 5039, 5051, 5059, 5077, 5081, 5087, 5099, 5101, 5107, 5113, 5119, 5147, 5153, 5167, 5171, 5179, 5189, 5197, 5209, 5227, 5231, 5233, 5237, 5261, 5273, 5279, 5281, 5297, 5303, 5309, 5323, 5333, 5347, 5351, 5381, 5387, 5393, 5399, 5407, 5413, 5417, 5419, 5431, 5437, 5441, 5443, 5449, 5471, 5477, 5479, 5483, 5501, 5503, 5507, 5519, 5521, 5527, 5531, 5557, 5563, 5569, 5573, 5581, 5591, 5623, 5639, 5641, 5647, 5651, 5653, 5657, 5659, 5669, 5683, 5689, 5693, 5701, 5711, 5717, 5737, 5741, 5743, 5749, 5779, 5783, 5791, 5801, 5807, 5813, 5821, 5827, 5839, 5843, 5849, 5851, 5857, 5861, 5867, 5869, 5879, 5881, 5897, 5903, 5923, 5927, 5939, 5953, 5981, 5987, 6007, 6011, 6029, 6037, 6043, 6047, 6053, 6067, 6073, 6079, 6089, 6091, 6101, 6113, 6121, 6131, 6133, 6143, 6151, 6163, 6173, 6197, 6199, 6203, 6211, 6217, 6221, 6229, 6247, 6257, 6263, 6269, 6271, 6277, 6287, 6299, 6301, 6311, 6317, 6323, 6329, 6337, 6343, 6353, 6359, 6361, 6367, 6373, 6379, 6389, 6397, 6421, 6427, 6449, 6451, 6469, 6473, 6481, 6491, 6521, 6529, 6547, 6551, 6553, 6563, 6569, 6571, 6577, 6581, 6599, 6607, 6619, 6637, 6653, 6659, 6661, 6673, 6679, 6689, 6691, 6701, 6703, 6709, 6719, 6733, 6737, 6761, 6763, 6779, 6781, 6791, 6793, 6803, 6823, 6827, 6829, 6833, 6841, 6857, 6863, 6869, 6871, 6883, 6899, 6907, 6911, 6917, 6947, 6949, 6959, 6961, 6967, 6971, 6977, 6983, 6991, 6997, 7001, 7013, 7019, 7027, 7039, 7043, 7057, 7069, 7079, 7103, 7109, 7121, 7127, 7129, 7151, 7159, 7177, 7187, 7193, 7207, 7211, 7213, 7219, 7229, 7237, 7243, 7247, 7253, 7283, 7297, 7307, 7309, 7321, 7331, 7333, 7349, 7351, 7369, 7393, 7411, 7417, 7433, 7451, 7457, 7459, 7477, 7481, 7487, 7489, 7499, 7507, 7517, 7523, 7529, 7537, 7541, 7547, 7549, 7559, 7561, 7573, 7577, 7583, 7589, 7591, 7603, 7607, 7621, 7639, 7643, 7649, 7669, 7673, 7681, 7687, 7691, 7699, 7703, 7717, 7723, 7727, 7741, 7753, 7757, 7759, 7789, 7793, 7817, 7823, 7829, 7841, 7853, 7867, 7873, 7877, 7879, 7883, 7901, 7907, 7919]
             ];
             Fact(nQubits<=Length(primes), $"The helper does not have {nQubits}-bit primes");
-            for (modulus in primes[nQubits-1]) {
+            for modulus in primes[nQubits-1] {
                 if (modulus % 4 == 3){//necessary for lazy point validation
-                    for( curveround in 0 .. modulus - 1 ) {
+                    for  curveround in 0 .. modulus - 1  {
                         //pick random elliptic curves
                         let ca = DrawRandomInt(0, modulus - 1);
                         let cb = DrawRandomInt(0, modulus - 1);
                         if ((4 * ca^3+27 * cb^2) % modulus != 0) {
-                            for (pointround in 0 .. modulus - 1){
+                            for pointround in 0 .. modulus - 1 {
                                 //pick several points on the curve to test
                                  let p1x = DrawRandomInt(0, modulus - 1);
                                  let p1signint = DrawRandomInt(0, 1);
@@ -366,7 +366,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nQubits : Int) : Unit {
       body (...) {
         // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits + addressSize]) {
+            use register = Qubit[2 * nQubits + addressSize] {
                 // Write to qubit registers
                 mutable qPoint = ClassicalECPointToQuantum(point2, register[0..2 * nQubits-1]);
                 mutable qAddress = LittleEndian(register[2* nQubits .. 2 * nQubits + addressSize - 1]);
@@ -386,8 +386,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 );
                 mutable actualAddress = MeasureBigInteger(qAddress);
                 Fact(IntAsBigInt(address) == actualAddress, $"Output : Expected {address}, got {actualAddress}");
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         //Write to qubit registers
                         set qPoint = ClassicalECPointToQuantum(point2, register[0..2 * nQubits-1]);
                         ApplyXorInPlaceL(IntAsBigInt(address), qAddress);
@@ -461,7 +461,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
             Fact(nQubits<=Length(primes), $"The helper does not have {nQubits}-bit primes");
             let nPrimes = Length(primes[nQubits  - 1]);
             mutable testedIdentity = false;
-            for (idxTest in 0 .. nTests - 1){
+            for idxTest in 0 .. nTests - 1 {
                 mutable success = false;
                 repeat {
                     let modulus = primes[nQubits - 1][DrawRandomInt(0, nPrimes - 1)]; 
@@ -483,7 +483,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
                             //3) Where cpoint+cPoint2 = -cPoint1
                             if (cPoint2::z and cPoint1::x != cPoint2::x and cPoint3::x != cPoint1::x){
                                 let address = DrawRandomInt(0, 2 ^ addressSize - 1);
-                                mutable points = new ECPointClassical[2^addressSize];
+                                mutable points = [ECPointClassical(0L,0L,true,0L), size = 2^addressSize];
                                 set points w/= address <- cPoint1;
                                 EllipticCurveWindowedPointAdditionTestHelper(WindowedPointAdder, points, cPoint2, address, addressSize, nQubits);
                                 set success = true;
@@ -515,7 +515,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nQubits : Int) : Unit {
       body (...) {
         // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits + addressSize]) {
+            use register = Qubit[2 * nQubits + addressSize] {
                 let modulus = point2::modulus;
 
                 // Compute expected classical value
@@ -548,8 +548,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 );
                 mutable actualAddress = MeasureBigInteger(qAddress);
                 Fact(IntAsBigInt(address) == actualAddress, $"Output : Expected {address}, got {actualAddress}");
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         //Write to qubit registers
                         set qPoint = ClassicalECPointToQuantum(point2, register[0..2 * nQubits-1]);
                         ApplyXorInPlaceL(IntAsBigInt(address), qAddress);
@@ -620,7 +620,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
             ];
             Fact(nQubits<=Length(primes), $"The helper does not have {nQubits}-bit primes");
             let nPrimes = Length(primes[nQubits  - 1]);
-            for (idxTest in 0 .. nTests - 1){
+            for idxTest in 0 .. nTests - 1 {
                 mutable success = false;
                 repeat {
                     let modulus = primes[nQubits - 1][DrawRandomInt(0, nPrimes - 1)]; 
@@ -690,7 +690,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         //idea: pick random point, add all doubled multiples of that point, and all doubled multiples of P
         let nBits = BitSizeL(curve::modulus);
-        for (idxTest in 0 .. nTests - 1){
+        for idxTest in 0 .. nTests - 1 {
             Message($"    Running test {idxTest} of {nTests}");
             let Q1 = MultiplyClassicalECPoint(generator, curve, RandomBigInt(curveOrder-1L)+1L);
             let Q2 = MultiplyClassicalECPoint(generator, curve, RandomBigInt(curveOrder-1L)+1L);
@@ -711,7 +711,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
             Secp256k1,
             Curve25519
         ];
-        for (curveFunction in curves){
+        for curveFunction in curves {
             let (curve, generator, curveOrder, name) = curveFunction();
             Message("Testing curve: " + name);
             ShorAdditionTestHelper(
@@ -741,7 +741,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         let points = [identity] + PointTable(startPoint, startPoint, curve, windowSize - 1);
         let Q = MultiplyClassicalECPoint(generator, curve, RandomBigInt(curveOrder-1L)+1L);
         Message("    Test prepped, about to run");
-        for (address in 0 .. 2^windowSize -1){
+        for address in 0 .. 2^windowSize -1 {
             Message($"Address: {address}");
             SignedEllipticCurveWindowedPointAdditionTestHelper(
                 SignedWindowedPointAdder, 
@@ -772,7 +772,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
             Secp256k1,
             Curve25519
         ];
-        for (curveFunction in curves){
+        for curveFunction in curves {
             let (curve, generator, curveOrder, name) = curveFunction();
             Message("Testing curve: " + name);
             ShorAdditionWindowedExhaustiveTestHelper(
@@ -797,7 +797,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         let windowSize = OptimalSignedPointAdditionWindowSize(nQubits);
         Message($"Window size: {windowSize}");
         
-        for (idxTest in 0 .. nTests - 1){
+        for idxTest in 0 .. nTests - 1 {
             Message($"    Prepping test {idxTest} of {nTests}");
             let startWindow = DrawRandomInt(0, nQubits - 1);
             let startPoint = MultiplyClassicalECPoint(generator, curve, 2L^startWindow);
@@ -834,7 +834,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
             Secp256k1,
             Curve25519
         ];
-        for (curveFunction in curves){
+        for curveFunction in curves {
             let (curve, generator, curveOrder, name) = curveFunction();
             Message("Testing curve: " + name);
             ShorAdditionWindowedRandomTestHelper(

--- a/MicrosoftQuantumCrypto/Tests/Fp2ArithmeticTests.qs
+++ b/MicrosoftQuantumCrypto/Tests/Fp2ArithmeticTests.qs
@@ -33,7 +33,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
     ///		* AddFp2ElementMontgomeryForm
      operation Fp2AddTestHelper( Adder:((Fp2MontModInt,Fp2MontModInt)=> Unit is Ctl), summand1 : Fp2ElementClassical, summand2 : Fp2ElementClassical, nQubits : Int ) : Unit {
        // Bookkeeping and qubit allocation
-       using (register = Qubit[4 * nQubits]) {
+       use register = Qubit[4 * nQubits] {
             // Write to qubit registers
             mutable summand1Q = CreateFp2MontModInt(summand1,register[0..2 * nQubits-1]);
             mutable summand2Q = CreateFp2MontModInt(summand2,register[2 * nQubits..4 * nQubits-1]);
@@ -50,8 +50,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
             mutable result = MeasureFp2MontModInt(summand2Q);
             Fact((expected::real == result::real) and (expected::imag == result::imag), $"Output: Expected {expected}, got {result}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                     //Write to qubit registers
                     set summand1Q = CreateFp2MontModInt(summand1,register[0..2 * nQubits-1]);
                     set summand2Q = CreateFp2MontModInt(summand2,register[2 * nQubits..4 * nQubits-1]);
@@ -89,7 +89,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
     }
 
     operation Fp2AddRandomTestHelper( Adder:((Fp2MontModInt,Fp2MontModInt)=> Unit is Ctl), nQubits:Int, nTests:Int):Unit {
-        for (roundnum in 0..nTests-1){
+        for roundnum in 0..nTests-1 {
             let modulus = RandomFp2Modulus(nQubits);
             let xFp2 = RandomFp2ElementClassical(modulus);
             let yFp2 = RandomFp2ElementClassical(modulus);
@@ -123,7 +123,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
     ///		* MulAndAddFp2ElementMontgomeryForm
      operation Fp2MultiplyTestHelper( Multiplier:((Fp2MontModInt,Fp2MontModInt,Fp2MontModInt)=> Unit is Ctl), multiplicand1 : Fp2ElementClassical, 
             multiplicand2 : Fp2ElementClassical, summand:Fp2ElementClassical, nQubits : Int ) : Unit {
-        using (register = Qubit[6 * nQubits]) {
+        use register = Qubit[6 * nQubits] {
             // Write to qubit register and create necessary variables
             mutable multiplicand1Q = CreateFp2MontModInt(multiplicand1,register[0..2 * nQubits-1]);
             mutable multiplicand2Q = CreateFp2MontModInt(multiplicand2,register[2 * nQubits..4 * nQubits-1]);
@@ -144,8 +144,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
             mutable result = MeasureFp2MontModInt(outputQ);
             Fact((expected::real == result::real) and (expected::imag == result::imag), $"Output: Expected {expected}, got {result}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                     // Write to qubit registers
                     set multiplicand1Q = CreateFp2MontModInt(multiplicand1,register[0..2 * nQubits-1]);
                     set multiplicand2Q = CreateFp2MontModInt(multiplicand2,register[2 * nQubits..4 * nQubits-1]);
@@ -189,7 +189,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
     }
 
     operation Fp2MultiplyAndXorRandomTestHelper( Multiplier:((Fp2MontModInt,Fp2MontModInt,Fp2MontModInt)=> Unit is Ctl),nQubits:Int,nTests:Int):Unit {
-        for (roundnum in 0..nTests-1){
+        for roundnum in 0..nTests-1 {
             let modulus = RandomFp2Modulus(nQubits);
             let xFp2 = RandomFp2ElementClassical(modulus);
             let yFp2 = RandomFp2ElementClassical(modulus);
@@ -203,7 +203,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         Fp2MultiplyAndXorRandomTestHelper(MulAndXorFp2ElementMontgomeryForm,nQubits,nTests);
     }
     operation Fp2MultiplyAndAddRandomTestHelper( Multiplier:((Fp2MontModInt,Fp2MontModInt,Fp2MontModInt)=> Unit is Ctl),nQubits:Int,nTests:Int):Unit {
-        for (roundnum in 0..nTests-1){
+        for roundnum in 0..nTests-1 {
             let modulus = RandomFp2Modulus(nQubits);
             let xFp2 = RandomFp2ElementClassical(modulus);
             let yFp2 = RandomFp2ElementClassical(modulus);
@@ -249,7 +249,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[6 * nQubits + nAncilla]){
+            use register = Qubit[6 * nQubits + nAncilla] {
                 let modulus = multiplier1::modulus;
                 let zeroFp2 = Fp2ElementClassical(modulus, 0L, 0L);
                 mutable actual1 = zeroFp2;
@@ -296,8 +296,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
                 set result = MeasureFp2MontModInt(resultQ);
                 Fact(IsEqualFp2Element(result, zeroFp2), $"Uncomputed: Result: Expected {0}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         //Write to qubit registers
                         EncodeFp2MontModInt(multiplier1, multiplier1Q);
                         EncodeFp2MontModInt(multiplier2, multiplier2Q);
@@ -381,7 +381,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         nAncilla : Int, 
         nTests:Int
         ):Unit {
-        for (roundnum in 0..nTests-1){
+        for roundnum in 0..nTests-1 {
             let modulus = RandomFp2Modulus(nQubits);
             let xFp2 = RandomFp2ElementClassical(modulus);
             let yFp2 = RandomFp2ElementClassical(modulus);
@@ -423,7 +423,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         multiplicand2 : Fp2ElementClassical, 
         summand:Fp2ElementClassical, 
         nQubits : Int ) : Unit {
-        using (register = Qubit[4 * nQubits]) {
+        use register = Qubit[4 * nQubits] {
             // Write to qubit registers and create qubit variables
             mutable multiplicand2Q = CreateFp2MontModInt(multiplicand2,register[0 * nQubits..2 * nQubits-1]);
             mutable outputQ = CreateFp2MontModInt(summand,register[2 * nQubits..4 * nQubits-1]);
@@ -441,8 +441,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
             mutable result = MeasureFp2MontModInt(outputQ);
             Fact((expected::real == result::real) and (expected::imag == result::imag), $"Output: Expected {expected}, got {result}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                     //Write to qubit registers
                     EncodeFp2MontModInt(multiplicand2, multiplicand2Q);
                     EncodeFp2MontModInt(summand, outputQ);
@@ -483,7 +483,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         Multiplier:((Fp2ElementClassical, Fp2MontModInt, Fp2MontModInt)=> Unit is Ctl),
         nQubits:Int,
         nTests:Int):Unit {
-        for (roundnum in 0..nTests-1){
+        for roundnum in 0..nTests-1 {
             let modulus = RandomFp2Modulus(nQubits);
             let xFp2 = RandomFp2ElementClassical(modulus);
             let yFp2 = RandomFp2ElementClassical(modulus);
@@ -531,7 +531,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[4 * nQubits + nAncilla]){
+            use register = Qubit[4 * nQubits + nAncilla] {
                 let ancillas = register[6 * nQubits .. 6 * nQubits + nAncilla - 1];
                 let ancillaLE = LittleEndian(ancillas);
                 mutable ancilla = 0L;
@@ -571,8 +571,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
                 set result = MeasureFp2MontModInt(resultQ);
                 Fact(IsEqualFp2Element(result, zeroFp2), $"Uncomputed: Result: Expected {0}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeFp2MontModInt(multiplier2, multiplier2Q);
 
@@ -644,7 +644,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         nAncilla : Int, 
         nTests:Int
         ):Unit {
-        for (roundnum in 0..nTests-1){
+        for roundnum in 0..nTests-1 {
             let modulus = RandomFp2Modulus(nQubits);
             let xFp2 = RandomFp2ElementClassical(modulus);
             let yFp2 = RandomFp2ElementClassical(modulus);
@@ -677,7 +677,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
     ///		* SquAndAddFp2ElementMontgomeryForm
      operation Fp2SquareTestHelper( Squarer:((Fp2MontModInt,Fp2MontModInt)=> Unit is Ctl), input : Fp2ElementClassical, 
              summand:Fp2ElementClassical, nQubits : Int ) : Unit {
-        using (register = Qubit[4 * nQubits]) {
+        use register = Qubit[4 * nQubits] {
             // Write to qubit registers and create variables
             mutable baseQ = CreateFp2MontModInt(input,register[0..2 * nQubits-1]);
             mutable outputQ = CreateFp2MontModInt(summand,register[2 * nQubits..4 * nQubits-1]);
@@ -695,8 +695,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
             mutable result = MeasureFp2MontModInt(outputQ);
             Fact((expected::real == result::real) and (expected::imag == result::imag), $"Output: Expected {expected}, got {result}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                     // Write to qubit registers
                     set baseQ = CreateFp2MontModInt(input,register[0..2 * nQubits-1]);
                     set outputQ = CreateFp2MontModInt(summand,register[2 * nQubits..4 * nQubits-1]);
@@ -734,7 +734,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
     }
 
     operation Fp2SquareAndXorRandomTestHelper( Squarer:((Fp2MontModInt,Fp2MontModInt)=> Unit is Ctl),nQubits:Int,nTests:Int):Unit {
-        for (roundnum in 0..nTests-1){
+        for roundnum in 0..nTests-1 {
             let modulus = RandomFp2Modulus(nQubits);
             let xFp2 = RandomFp2ElementClassical(modulus);
             let zeroFp2 = Fp2ElementClassical(modulus, 0L,0L);
@@ -747,7 +747,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         Fp2SquareAndXorRandomTestHelper(SquAndXorFp2ElementMontgomeryForm,nQubits,nTests);
     }
     operation Fp2SquareAndAddRandomTestHelper( Squarer:((Fp2MontModInt,Fp2MontModInt)=> Unit is Ctl),nQubits:Int,nTests:Int):Unit {
-        for (roundnum in 0..nTests-1){
+        for roundnum in 0..nTests-1 {
             let modulus = RandomFp2Modulus(nQubits);
             let xFp2 = RandomFp2ElementClassical(modulus);
             let yFp2 = RandomFp2ElementClassical(modulus);
@@ -786,7 +786,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         nAncilla : Int 
         ) : Unit {
         body (...) {
-            using (register = Qubit[4 * nQubits + nAncilla]){
+            use register = Qubit[4 * nQubits + nAncilla] {
                 // Bookkeeping and allocation
                 let modulus = input::modulus;
                 let zeroFp2 = Fp2ElementClassical(modulus, 0L, 0L);
@@ -827,8 +827,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
                 set result = MeasureFp2MontModInt(resultQ);
                 Fact(IsEqualFp2Element(result, zeroFp2), $"Uncomputed: Result: Expected {0}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeFp2MontModInt(input, inputQ);
 
@@ -900,7 +900,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         nAncilla : Int, 
         nTests:Int
         ):Unit {
-        for (roundnum in 0..nTests-1){
+        for roundnum in 0..nTests-1 {
             let modulus = RandomFp2Modulus(nQubits);
             let xFp2 = RandomFp2ElementClassical(modulus);
             let yFp2 = RandomFp2ElementClassical(modulus);
@@ -931,7 +931,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
     ///		* InvertAndAddFp2ElementMontgomeryForm
     operation Fp2InverseTestHelper( Inverter:((Fp2MontModInt,Fp2MontModInt)=> Unit is Ctl), input : Fp2ElementClassical, 
              summand:Fp2ElementClassical, nQubits : Int ) : Unit {
-        using (register = Qubit[4 * nQubits]) {
+        use register = Qubit[4 * nQubits] {
             // Write to qubit registers and create variables
             mutable baseQ = CreateFp2MontModInt(input,register[0..2 * nQubits-1]);
             mutable outputQ = CreateFp2MontModInt(summand,register[2 * nQubits..4 * nQubits-1]);
@@ -952,8 +952,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
             mutable result = MeasureFp2MontModInt(outputQ);
             Fact((expected::real == result::real) and (expected::imag == result::imag), $"Output: Expected {expected}, got {result}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                     // Write to qubit registers
                     set baseQ = CreateFp2MontModInt(input,register[0..2 * nQubits-1]);
                     set outputQ = CreateFp2MontModInt(summand,register[2 * nQubits..4 * nQubits-1]);
@@ -1036,7 +1036,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
         nAncilla : Int 
         ) : Unit {
         body (...) {
-            using (register = Qubit[4 * nQubits + nAncilla]){
+            use register = Qubit[4 * nQubits + nAncilla] {
                 // Bookkeeping and qubit allocation
                 let modulus = input::modulus;
                 let zeroFp2 = Fp2ElementClassical(modulus, 0L, 0L);
@@ -1080,8 +1080,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
                 set result = MeasureFp2MontModInt(resultQ);
                 Fact(IsEqualFp2Element(result, zeroFp2), $"Uncomputed: Result: Expected {0}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeFp2MontModInt(input, inputQ);
 
@@ -1189,7 +1189,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
     ///		* DivideAndAddFp2ElementMontgomeryForm
      operation Fp2DivideTestHelper( Divider:((Fp2MontModInt,Fp2MontModInt,Fp2MontModInt)=> Unit is Ctl), invertand : Fp2ElementClassical, 
             multiplicand : Fp2ElementClassical, summand:Fp2ElementClassical, nQubits : Int ) : Unit {
-        using (register = Qubit[6 * nQubits]) {
+        use register = Qubit[6 * nQubits] {
             // Write to qubit registers and create variables
             mutable invertandQ = CreateFp2MontModInt(invertand,register[0..2 * nQubits-1]);
             mutable multiplicandQ = CreateFp2MontModInt(multiplicand,register[2 * nQubits..4 * nQubits-1]);
@@ -1214,8 +1214,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Fp2Arithmetic {
             mutable result = MeasureFp2MontModInt(outputQ);
             Fact((expected::real == result::real) and (expected::imag == result::imag), $"Output: Expected {expected}, got {result}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                     // Write to qubit registers
                     set invertandQ = CreateFp2MontModInt(invertand,register[0..2 * nQubits-1]);
                     set multiplicandQ = CreateFp2MontModInt(multiplicand,register[2 * nQubits..4 * nQubits-1]);

--- a/MicrosoftQuantumCrypto/Tests/IsogenyTests.qs
+++ b/MicrosoftQuantumCrypto/Tests/IsogenyTests.qs
@@ -608,7 +608,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
     /// required bit size.
     /// If no such two torsion exists, returns -1.
     function SIKETwoTorsionForBitSize(nBits : Int) : Int {
-        for (twoTorsion in 4 .. 3 * nBits){
+        for twoTorsion in 4 .. 3 * nBits {
             let SIKEps = GetSIKEParams(twoTorsion);
             if (BitSizeL(SIKEps::prime) == nBits){
                 return twoTorsion;
@@ -647,7 +647,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
     ) : Unit {
       body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[12*nQubits]) {
+            use register = Qubit[12*nQubits] {
                 let modulus = point::x::modulus;
                 let zeropoint = ECPointMontgomeryXZClassical(
                     Fp2ElementClassical(modulus, 0L,0L),
@@ -685,8 +685,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
                     , got ({actualpoint2::x::real} + {actualpoint2::x::imag}i,{actualpoint2::z::real} + {actualpoint2::z::imag}i)"
                 );
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         set qpoint1 = CreateECPointMontgomeryXZ(point,register[0..4*nQubits - 1]);
                         set qpoint2 = CreateECPointMontgomeryXZ(zeropoint,register[4*nQubits..8*nQubits - 1]);
@@ -863,7 +863,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
 
     operation ECPointMontgomeryXZPointDoublerRandomTestHelper(PointDoubler : ((ECPointMontgomeryXZ,ECCoordsMontgomeryFormAPlusC,ECPointMontgomeryXZ)=>Unit is Ctl),
         nQubits : Int,nTests : Int) : Unit {
-        for (roundnum in 0..nTests - 1){
+        for roundnum in 0..nTests - 1 {
             let modulus = RandomFp2Modulus(nQubits);
 
             let point = ECPointMontgomeryXZClassical(
@@ -916,7 +916,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
         ) : Unit {
         body (...) {
             // Bookkeeping and ancilla allocation
-            using (register = Qubit[12 * nQubits + nAncillas]){
+            use register = Qubit[12 * nQubits + nAncillas] {
                 let modulus = point::x::modulus;
                 let zeroFp2 = Fp2ElementClassical(modulus, 0L, 0L);
                 let zeroPoint = ECPointMontgomeryXZClassical(zeroFp2, zeroFp2);
@@ -964,8 +964,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
                 set result = MeasureECPointMontgomeryXZ(qResult);
                 Fact(IsEqualMontgomeryXZClassical(result, zeroPoint), $"Uncomputed : Result : Expected {0}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeECPointMontgomeryXZ(point, qPoint);
                         EncodeECCoordsMontgomeryFormAPlusC(curve, qCurve);
@@ -1124,7 +1124,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
         ) : Unit {
         body (...) {
             // Bookkeeping and ancilla allocation
-            using (register = Qubit[12 * nQubits + nAncillas]){
+            use register = Qubit[12 * nQubits + nAncillas] {
                 let modulus = pointP::x::modulus;
                 let zeroFp2 = Fp2ElementClassical(modulus, 0L, 0L);
                 let zeroPoint = ECPointMontgomeryXZClassical(zeroFp2, zeroFp2);
@@ -1172,8 +1172,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
                 set result = MeasureECPointMontgomeryXZ(qResult);
                 Fact(IsEqualMontgomeryXZClassical(result, zeroPoint), $"Uncomputed : Result : Expected {0}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeECPointMontgomeryXZ(pointQ, qPointQ);
                         EncodeECPointMontgomeryXZ(pointR, qPointR);
@@ -1359,7 +1359,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
         body (...){
             // Bookkeeping and qubit allocation
             let coefficientSize = Max([BitSizeL(coefficient), nQubits]);
-            using (register = Qubit[4 * nQubits + coefficientSize]) {
+            use register = Qubit[4 * nQubits + coefficientSize] {
                 mutable actualCoefficient = 0L;
                 let modulus = curve::a24Plus::modulus;
                 let zeroPoint = ECPointMontgomeryXZClassical(
@@ -1389,8 +1389,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
                     , got ({actualPoint::x::real} + {actualPoint::x::imag}i,{actualPoint::z::real} + {actualPoint::z::imag}i)"
                 );
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         ApplyXorInPlaceL(coefficient, qCoefficient);
 
@@ -1452,7 +1452,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
             Fp2ElementClassical(SIKEps::prime, 8L, 0L),
             Fp2ElementClassical(SIKEps::prime, 4L, 0L)
         );
-        for (idxTest in 0..nTests - 1){
+        for idxTest in 0..nTests - 1 {
             let coefficient = RandomBigInt(2L^twoTorsion);
             Message($"Finished {idxTest} tests");
             PointLadderTestHelper(
@@ -1511,7 +1511,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
     ) : Unit {
         body (...){
             // Bookkeeping and qubit allocation
-            using (register = Qubit[12 * nQubits]) {
+            use register = Qubit[12 * nQubits] {
                 mutable actualCoefficient = 0L;
                 let modulus = curve::a24Plus::modulus;
                 let zeroPoint = ECPointMontgomeryXZClassical(
@@ -1532,7 +1532,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
  
                 // Compute expected classical result
                 mutable doubledPoint = point;
-                for (idx in 1..nDoublings){
+                for idx in 1..nDoublings {
                     set doubledPoint = PointDoubleMontgomeryXZClassical(doubledPoint, curve);
                 }
 
@@ -1556,8 +1556,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
                     , got ({resultPoint::x::real} + {resultPoint::x::imag}i,{resultPoint::z::real} + {resultPoint::z::imag}i)"
                 );
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeECPointMontgomeryXZ(point, qPoint);
                         EncodeECCoordsMontgomeryFormAPlusC(curve, qCurve);
@@ -1692,7 +1692,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
         ) : Unit {
         body (...) {
             // Bookkeeping and ancilla allocation
-            using (register = Qubit[6 * nQubits + nAncillas]){
+            use register = Qubit[6 * nQubits + nAncillas] {
                 let modulus = curve::aCoeff::modulus;
                 let zeroFp2 = Fp2ElementClassical(modulus, 0L, 0L);
                 let zeroCurve = ECCoordsMontgomeryFormACClassical(zeroFp2, zeroFp2);
@@ -1736,8 +1736,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
                 set result = MeasureFp2MontModInt(qResult);
                 Fact(IsEqualFp2Element(result, zeroFp2), $"Uncomputed :Result : Expected {zeroFp2}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeECCoordsMontgomeryFormAC(curve, qCurve);
 
@@ -1822,7 +1822,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
         nAncilla : Int,
         nTests : Int
     ) : Unit {
-        for (idxTest in 0.. nTests - 1){
+        for idxTest in 0.. nTests - 1 {
             mutable modulus = RandomFp2Modulus(nQubits);
             let curve = RandomECCoordsMontgomeryAC(modulus);
             JInvariantACOpenTestHelper(JInvariant, curve, nQubits, nAncilla);
@@ -1867,7 +1867,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
     ) : Unit {
         body (...){
             // Bookkeeping and qubit allocation
-            using (register = Qubit[12 * nQubits]) {
+            use register = Qubit[12 * nQubits] {
                 mutable actualCoefficient = 0L;
                 let modulus = kernelPoint::x::modulus;
                 let zeroPoint = ECPointMontgomeryXZClassical(
@@ -1909,8 +1909,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
                     , got ({resultPoint::x::real} + {resultPoint::x::imag}i,{resultPoint::z::real} + {resultPoint::z::imag}i)"
                 );
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeECPointMontgomeryXZ(kernelPoint, qKernelPoint);
                         EncodeECPointMontgomeryXZ(inputPoint, qInputPoint);
@@ -2026,8 +2026,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
         let twoTorsions = [pPoints[e2 - 1], qPoints[e2 - 1], rPoints[e2 - 1]];
         let threePoints = [P3, Q3, R3];
 
-        for (idxTwo in 0..2){
-            for (idxThree in 0..2){
+        for idxTwo in 0..2 {
+            for idxThree in 0..2 {
                 TwoIsogenyOfPointTestHelper(Isogeny, twoTorsions[idxTwo], threePoints[idxThree], nQubits);
             }
         }
@@ -2102,8 +2102,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
         let twoTorsions = [pPoints[e2 - 1], qPoints[e2 - 1], rPoints[e2 - 1]];
         let threePoints = [P3, Q3, R3];
 
-        for (idxTwo in 0..2){
-            for (idxThree in 0..2){
+        for idxTwo in 0..2 {
+            for idxThree in 0..2 {
                 TwoIsogenyOfPointTestHelper(Isogeny, twoTorsions[idxTwo], threePoints[idxThree], nQubits);
             }
         }
@@ -2129,7 +2129,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
         nQubits : Int,
         nTests : Int
     ) : Unit {
-        for (idxTest in 0.. nTests - 1){
+        for idxTest in 0.. nTests - 1 {
             let modulus = RandomFp2Modulus(nQubits);
             let pxFp2 = RandomFp2ElementClassical(modulus);
             let pzFp2 = RandomFp2ElementClassical(modulus);
@@ -2175,7 +2175,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
     ) : Unit {
         body (...){
             // Bookkeeping and qubit allocation
-            using (register = Qubit[8 * nQubits]) {
+            use register = Qubit[8 * nQubits] {
                 mutable actualCoefficient = 0L;
                 let modulus = kernelPoint::x::modulus;
                 let zeroPoint = ECPointMontgomeryXZClassical(
@@ -2210,8 +2210,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
                 Fact(IsEqualFp2Element(imageCurve::a24Plus, resultCurve::a24Plus)
                             and IsEqualFp2Element(imageCurve::c24, resultCurve::c24), 
                             $"Isogenous curve : Expected {imageCurve}, got {resultCurve}");
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeECPointMontgomeryXZ(kernelPoint, qKernelPoint);
 
@@ -2295,7 +2295,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
 
         let twoTorsions = [pPoints[e2 - 1], qPoints[e2 - 1], rPoints[e2 - 1]];
 
-        for (idxTwo in 0..2){
+        for idxTwo in 0..2 {
             TwoIsogenyOfCurveTestHelper(Isogeny, twoTorsions[idxTwo], nQubits);
         }
     }
@@ -2346,7 +2346,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
 
         let twoTorsions = [pPoints[e2 - 1], qPoints[e2 - 1], rPoints[e2 - 1]];
 
-        for (idxTwo in 0..2){
+        for idxTwo in 0..2 {
             TwoIsogenyOfCurveTestHelper(Isogeny, twoTorsions[idxTwo], nQubits);
         }
     }
@@ -2370,7 +2370,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
         nQubits : Int,
         nTests : Int
     ) : Unit {
-        for (idxTest in 0.. nTests - 1){
+        for idxTest in 0.. nTests - 1 {
             let modulus = RandomFp2Modulus(nQubits);
             let pxFp2 = RandomFp2ElementClassical(modulus);
             let pzFp2 = RandomFp2ElementClassical(modulus);
@@ -2415,7 +2415,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
     ) : Unit {
         body (...){
             // Bookkeeping and qubit allocation
-            using (register = Qubit[height + 2 * nQubits]) {
+            use register = Qubit[height + 2 * nQubits] {
                 mutable actualCoefficient = 0L;
                 let modulus = pointP::x::modulus;
                 let zeroFp2 = Fp2ElementClassical(modulus, 0L, 0L);
@@ -2444,8 +2444,8 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
                     $"J-invariant : Expected ({trueJInvariant::real} + {trueJInvariant::imag}i), got ({actualJInvariant::real} + {actualJInvariant::imag}i)"
                 );
                 Fact(actualCoefficient == coefficient, $"Coefficient: Expected {coefficient}, got {actualCoefficient}");
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         ApplyXorInPlaceL(coefficient, qCoefficient);
 
@@ -2505,7 +2505,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
             Fp2ElementClassical(SIKEps::prime, 8L, 0L),
             Fp2ElementClassical(SIKEps::prime, 4L, 0L)
         );
-        for (idxTest in 0..nTests - 1){
+        for idxTest in 0..nTests - 1 {
 
             let coefficient = RandomBigInt(2L ^ SIKEps::twoOrder);
             SIKEIsogenyTestHelper(
@@ -2528,7 +2528,7 @@ namespace Microsoft.Quantum.Crypto.Tests.Isogenies {
     }
 
     operation InreasingSIKEIsogenyTest () : Unit {
-        for (twoTorsion in 13.. 128){
+        for twoTorsion in 13.. 128 {
             Message($"============================================================
             
           TESTING TWO TORSION OF {twoTorsion}

--- a/MicrosoftQuantumCrypto/Tests/ModularArithmeticTests.qs
+++ b/MicrosoftQuantumCrypto/Tests/ModularArithmeticTests.qs
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         modulus : BigInt, 
         nQubits : Int 
      ) : Unit {
-        using (register = Qubit[3 * nQubits]) {
+        use register = Qubit[3 * nQubits] {
             // Bookkeeping and ancilla allocation
             mutable actual1 = 0L;
             mutable actual2 = 0L;
@@ -73,8 +73,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
             set actualm = MeasureBigInteger(modulusLE);
             Fact(modulus== actualm, $"Expected {modulus}, got {actualm}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                     // Write to qubit registers
                     ApplyXorInPlaceL(summand1, summand1LE);
                     ApplyXorInPlaceL(summand2, summand2LE);
@@ -118,9 +118,9 @@ namespace Microsoft.Quantum.Crypto.Tests {
     }
 
     operation ModularAddExhaustiveTestHelper (Adder : ((LittleEndian, LittleEndian, LittleEndian) => Unit is Ctl), nQubits : Int) : Unit {
-        for( modulus in 2^(nQubits-1) .. 2^nQubits - 1 ) {
-            for( summand1 in 0 .. modulus - 1 ) {
-                for( summand2 in 0 .. modulus - 1 ) {
+        for  modulus in 2^(nQubits-1) .. 2^nQubits - 1  {
+            for  summand1 in 0 .. modulus - 1  {
+                for  summand2 in 0 .. modulus - 1  {
                     ModularAddTestHelper(Adder, IntAsBigInt(summand1), IntAsBigInt(summand2), IntAsBigInt(modulus), nQubits);
                 }
             }
@@ -178,7 +178,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         modulus : BigInt, 
         nQubits : Int 
     ) : Unit {
-        using (register = Qubit[2 * nQubits]) {
+        use register = Qubit[2 * nQubits] {
             // Bookkeeping and qubit allocation
             mutable actual1 = 0L;
             mutable actualm = 0L;
@@ -201,8 +201,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
             set actualm = MeasureBigInteger(modulusLE);
             Fact(modulus== actualm, $"Expected {modulus}, got {actualm}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                     // Write to qubit registers
                     ApplyXorInPlaceL(integer, integerLE);
                     ApplyXorInPlaceL(modulus, modulusLE);
@@ -240,8 +240,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
     }
 
     operation ModularNegExhaustiveTestHelper (Negater : ((LittleEndian, LittleEndian) => Unit is Ctl), nQubits : Int) : Unit {
-        for(modulus in 2^(nQubits-1) .. 2^nQubits - 1 ) {
-            for(integer in 0 .. modulus - 1 ) {
+        for modulus in 2^(nQubits-1) .. 2^nQubits - 1  {
+            for integer in 0 .. modulus - 1  {
                 ModularNegTestHelper(Negater, IntAsBigInt(integer), IntAsBigInt(modulus), nQubits);
             }
         }
@@ -296,7 +296,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         modulus : BigInt, 
         nQubits : Int 
     ) : Unit {
-        using (register = Qubit[2 * nQubits]) {
+        use register = Qubit[2 * nQubits] {
             // Bookkeeping and ancilla allocation
             mutable actual1 = 0L;
             mutable actualm = 0L;
@@ -319,8 +319,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
             set actualm = MeasureBigInteger(modulusLE);
             Fact(modulus== actualm, $"Expected {modulus}, got {actualm}");
 
-            for (numberOfControls in 1..2) { 
-                using (controls = Qubit[numberOfControls]) {
+            for numberOfControls in 1..2 { 
+                use controls = Qubit[numberOfControls] {
                     // Write to qubit registers
                     ApplyXorInPlaceL(integer, integerLE);
                     ApplyXorInPlaceL(modulus, modulusLE);
@@ -359,8 +359,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
     operation ModularDblExhaustiveTestHelper (Doubler : ((LittleEndian, LittleEndian) => Unit is Ctl), nQubits : Int) : Unit {
         body (...) {
-            for( modulus in 2^(nQubits-1) + 1 ..2.. 2^nQubits - 1) {
-                for( integer in 0 .. modulus - 1 ) {
+            for  modulus in 2^(nQubits-1) + 1 ..2.. 2^nQubits - 1 {
+                for  integer in 0 .. modulus - 1  {
                     ModularDblTestHelper(Doubler, IntAsBigInt(integer), IntAsBigInt(modulus), nQubits);
                 }
             }
@@ -431,7 +431,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             //Bookkeeping and qubit allocation
-            using (register = Qubit[4 * nQubits]) {
+            use register = Qubit[4 * nQubits] {
                 mutable actual1 = 0L;
                 mutable actual2 = 0L;
                 mutable actualr = 0L;
@@ -464,8 +464,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actualr = MeasureBigInteger(resultLE);
                 Fact(expected== actualr, $"Expected {expected}, got {actualr}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         ApplyXorInPlaceL(multiplier1, multiplier1LE);
                         ApplyXorInPlaceL(multiplier2, multiplier2LE);
@@ -517,9 +517,9 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
    operation ModularMultiplierExhaustiveTestHelper ( ModularMultiplier : ( (LittleEndian, LittleEndian, LittleEndian, LittleEndian) => Unit is Ctl), nQubits : Int ) : Unit {
         body (...) {
-            for( modulus in 2^(nQubits-1)+1 ..2.. 2^nQubits - 1 ) {
-                for( multiplier1 in 0 .. modulus - 1 ) {
-                    for( multiplier2 in 0 .. modulus - 1 ) {
+            for  modulus in 2^(nQubits-1)+1 ..2.. 2^nQubits - 1  {
+                for  multiplier1 in 0 .. modulus - 1  {
+                    for  multiplier2 in 0 .. modulus - 1  {
                         ModularMultiplierTestHelper(ModularMultiplier, IntAsBigInt(multiplier1), IntAsBigInt(multiplier2), IntAsBigInt(modulus), nQubits);
                     }
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     operation ModularSquarerTestHelper( ModularSquarer : ( (LittleEndian, LittleEndian, LittleEndian) => Unit is Ctl), integer : BigInt, modulus : BigInt, nQubits : Int ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[3 * nQubits]) {
+            use register = Qubit[3 * nQubits] {
                 mutable actual = 0L;
                 mutable actualr = 0L;
                 mutable actualm = 0L;
@@ -613,8 +613,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actualr = MeasureBigInteger(resultLE);
                 Fact(expected==actualr, $"Expected {expected}, got {actualr}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         ApplyXorInPlaceL(integer, integerLE);
                         ApplyXorInPlaceL(0L, resultLE);
@@ -660,8 +660,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
    operation ModularSquarerExhaustiveTestHelper ( ModularSquarer : ( (LittleEndian, LittleEndian, LittleEndian) => Unit is Ctl), nQubits : Int ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( integer in 0 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  integer in 0 .. modulus - 1  {
                     ModularSquarerTestHelper(ModularSquarer, IntAsBigInt(integer), IntAsBigInt(modulus), nQubits);
                 }
             }
@@ -722,7 +722,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
    operation ModularAddConstantModulusTestHelper(ModularAdder : ((BigInt, LittleEndian, LittleEndian) => Unit is Ctl), summand1 : BigInt, summand2 : BigInt, modulus : BigInt, nQubits : Int ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits]) {
+            use register = Qubit[2 * nQubits] {
                 mutable actual1 = 0L;
                 mutable actual2 = 0L;
                 let summand1LE = LittleEndian(register[0 .. nQubits - 1]);
@@ -744,8 +744,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actual2 = MeasureBigInteger(summand2LE);
                 Fact(expected== actual2, $"Expected {expected}, got {actual2}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         ApplyXorInPlaceL(summand1, summand1LE);
                         ApplyXorInPlaceL(summand2, summand2LE);
@@ -785,9 +785,9 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
     operation ModularAddConstantModulusExhaustiveTestHelper (ModularAdder : ((BigInt, LittleEndian, LittleEndian) => Unit is Ctl), nQubits : Int) : Unit {
         body (...) {
-            for( modulus in 2^(nQubits-1) .. 2^nQubits - 1 ) {
-                for( summand1 in 0 .. modulus - 1 ) {
-                    for( summand2 in 0 .. modulus - 1 ) {
+            for  modulus in 2^(nQubits-1) .. 2^nQubits - 1  {
+                for  summand1 in 0 .. modulus - 1  {
+                    for  summand2 in 0 .. modulus - 1  {
                         ModularAddConstantModulusTestHelper(ModularAdder, IntAsBigInt(summand1), IntAsBigInt(summand2), IntAsBigInt(modulus), nQubits);
                     }
                 }
@@ -824,7 +824,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
     operation ModularAddConstantModulusExhaustiveTestReversible () : Unit {
         body (...) {
-            for (nQubits in 2..15) {
+            for nQubits in 2..15 {
                 ModularAddConstantModulusExhaustiveTestHelper (ModularAddConstantModulus, nQubits);
             }
         }
@@ -856,7 +856,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits]) {
+            use register = Qubit[2 * nQubits] {
                 mutable actual1 = 0L;
                 let integerLE = LittleEndian(register[0 .. nQubits - 1]);
  
@@ -873,8 +873,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actual1 = MeasureBigInteger(integerLE);
                 Fact(expected==actual1, $"Expected {expected}, got {actual1}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit register
                         ApplyXorInPlaceL(integer, integerLE);
 
@@ -898,8 +898,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
     operation ModularDblConstantModulusExhaustiveTestHelper (Doubler : ((BigInt, LittleEndian) => Unit is Ctl), nQubits : Int) : Unit {
         body (...) {
-            for( modulus in 2^(nQubits-1) + 1 ..2.. 2^nQubits - 1) {
-                for( integer in 0 .. modulus - 1 ) {
+            for  modulus in 2^(nQubits-1) + 1 ..2.. 2^nQubits - 1 {
+                for  integer in 0 .. modulus - 1  {
                     ModularDblConstantModulusTestHelper(Doubler, IntAsBigInt(integer), IntAsBigInt(modulus), nQubits);
                 }
             }
@@ -961,7 +961,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
    operation ModularAddConstantConstantModulusTestHelper( Adder:((BigInt, BigInt, LittleEndian) => Unit is Ctl), summand1 : BigInt, summand2 : BigInt, modulus : BigInt, nQubits : Int ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits]) {
+            use register = Qubit[2 * nQubits] {
                 mutable actual1 = 0L;
                 let summand1LE = LittleEndian(register[0 .. nQubits - 1]);
                 let summand2LE = LittleEndian(register[nQubits .. 2 * nQubits - 1]);
@@ -979,8 +979,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actual1 = MeasureBigInteger(summand1LE);
                 Fact(expected== actual1, $"Expected {expected}, got {actual1}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit register
                         ApplyXorInPlaceL(summand1, summand1LE);
 
@@ -1014,9 +1014,9 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
     operation ModularAddConstantConstantModulusExhaustiveTestHelper (Adder:((BigInt, BigInt, LittleEndian)=>Unit is Ctl), nQubits : Int) : Unit {
         body (...) {
-            for( modulus in 2^(nQubits-1) .. 2^nQubits - 1 ) {
-                for( summand1 in 0 .. modulus - 1) {
-                    for( summand2 in 0 .. modulus - 1 ) {
+            for  modulus in 2^(nQubits-1) .. 2^nQubits - 1  {
+                for  summand1 in 0 .. modulus - 1 {
+                    for  summand2 in 0 .. modulus - 1  {
                         ModularAddConstantConstantModulusTestHelper(Adder, IntAsBigInt(summand1), IntAsBigInt(summand2), IntAsBigInt(modulus), nQubits);
                     }
                 }
@@ -1106,7 +1106,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[3 * nQubits]) {
+            use register = Qubit[3 * nQubits] {
                 mutable actual1 = 0L;
                 mutable actual2 = 0L;
                 mutable actualr = 0L;
@@ -1134,8 +1134,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actualr = MeasureBigInteger(resultLE);
                 Fact(expected== actualr, $"Expected {expected}, got {actualr}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         ApplyXorInPlaceL(multiplier1, multiplier1LE);
                         ApplyXorInPlaceL(multiplier2, multiplier2LE);
@@ -1181,9 +1181,9 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
    operation ModularMultiplierConstantModulusExhaustiveTestHelper ( ModularMultiplier : ( (BigInt, LittleEndian, LittleEndian, LittleEndian) => Unit is Ctl), nQubits : Int ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( multiplier1 in 0 .. modulus - 1 ) {
-                    for( multiplier2 in 0 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  multiplier1 in 0 .. modulus - 1  {
+                    for  multiplier2 in 0 .. modulus - 1  {
                         ModularMultiplierConstantModulusTestHelper(ModularMultiplier, IntAsBigInt(multiplier1), IntAsBigInt(multiplier2), IntAsBigInt(modulus), nQubits);
                     }
                 }
@@ -1248,7 +1248,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     operation ModularSquarerConstantModulusTestHelper( ModularSquarer : ( (BigInt, LittleEndian, LittleEndian) => Unit is Ctl), integer : BigInt, modulus : BigInt, nQubits : Int ) : Unit {
         body (...) {
             // Bookkeeping and ancilla allocation
-            using (register = Qubit[2 * nQubits]) {
+            use register = Qubit[2 * nQubits] {
                 mutable actual = 0L;
                 mutable actualr = 0L;
                 let integerLE = LittleEndian(register[0 .. nQubits - 1]);
@@ -1271,8 +1271,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actualr = MeasureBigInteger(resultLE);
                 Fact(expected== actualr, $"Expected {expected}, got {actualr}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit register
                         ApplyXorInPlaceL(integer, integerLE);
                         ApplyXorInPlaceL(0L, resultLE);
@@ -1312,8 +1312,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
    operation ModularSquarerConstantModulusExhaustiveTestHelper ( ModularSquarer : ( (BigInt, LittleEndian, LittleEndian) => Unit is Ctl), nQubits : Int ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( integer in 0 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  integer in 0 .. modulus - 1  {
                     ModularSquarerConstantModulusTestHelper(ModularSquarer, IntAsBigInt(integer), IntAsBigInt(modulus), nQubits);
                 }
             }
@@ -1373,7 +1373,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     operation ModularNegConstantModulusTestHelper(Negater : ((BigInt, LittleEndian) => Unit is Ctl + Adj), integer : BigInt, modulus : BigInt, nQubits : Int ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation 
-            using (register = Qubit[nQubits]) {
+            use register = Qubit[nQubits] {
                 mutable actual1 = 0L;
                 let integerLE = LittleEndian(register[0 .. nQubits - 1]);
  
@@ -1390,8 +1390,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actual1 = MeasureBigInteger(integerLE);
                 Fact(expected== actual1, $"Expected {expected}, got {actual1}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit register
                         ApplyXorInPlaceL(integer, integerLE);
 
@@ -1425,8 +1425,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
     operation ModularNegConstantModulusExhaustiveTestHelper (Negater : ((BigInt, LittleEndian) => Unit is Ctl + Adj), nQubits : Int) : Unit {
         body (...) {
-             for( modulus in 2^(nQubits-1) .. 2^nQubits - 1 ) {
-                for( integer in 0 .. modulus - 1 ) {
+             for  modulus in 2^(nQubits-1) .. 2^nQubits - 1  {
+                for  integer in 0 .. modulus - 1  {
                     ModularNegConstantModulusTestHelper(Negater, IntAsBigInt(integer), IntAsBigInt(modulus), nQubits);
                 }
             }
@@ -1494,7 +1494,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits]) {
+            use register = Qubit[2 * nQubits] {
                 mutable actual = 0L;
                 mutable actualr = 0L;
                 let integerLE = LittleEndian(register[0 .. nQubits - 1]);
@@ -1516,8 +1516,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actualr = MeasureBigInteger(resultLE);
                 Fact(expected== actualr, $"Non-controlled result: Expected {expected}, got {actualr}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         ApplyXorInPlaceL(integer, integerLE);
                         ApplyXorInPlaceL(0L, resultLE);
@@ -1560,9 +1560,9 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nQubits : Int 
     ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( integer in 0 .. modulus - 1 ) {
-                    for( constant in 0 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  integer in 0 .. modulus - 1  {
+                    for  constant in 0 .. modulus - 1  {
                         ModularConstantMultipleConstantModulusTestHelper(
                             ModularConstantMultiplier, 
                             IntAsBigInt(integer), 
@@ -1621,7 +1621,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and ancilla allocation
-            using (register = Qubit[nQubits]) {
+            use register = Qubit[nQubits] {
                 mutable actual = 0L;
                 let integerLE = LittleEndian(register[0 .. nQubits - 1]);
  
@@ -1638,8 +1638,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actual = MeasureBigInteger(integerLE);
                 Fact(expected==actual, $"Non-controlled Result: Expected {integer}, got {actual}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit register
                         ApplyXorInPlaceL(integer, integerLE);
 
@@ -1676,9 +1676,9 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nQubits : Int 
     ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( integer in 1 .. modulus - 1 ) {
-                    for( constant in 1 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  integer in 1 .. modulus - 1  {
+                    for  constant in 1 .. modulus - 1  {
                         if (GreatestCommonDivisorI(integer, constant)==1){
                             ModularMultiplyInPlaceTestHelper(
                                 ModularConstantMultiplier, 
@@ -1752,7 +1752,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[3 * nQubits]) {
+            use register = Qubit[3 * nQubits] {
                 mutable actual1 = 0L;
                 mutable actual2 = 0L;
                 mutable actualr = 0L;
@@ -1778,8 +1778,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actualr = MeasureMontgomeryInteger(resultMMI);
                 Fact(expected== actualr, $"Expected {expected} as product, got {actualr}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeBigIntInMontgomeryForm(multiplier1, multiplier1MMI);
                         EncodeBigIntInMontgomeryForm(multiplier2, multiplier2MMI);
@@ -1828,10 +1828,10 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nQubits : Int 
     ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( multiplier1 in 0 .. modulus - 1 ) {
-                    for( multiplier2 in 0 .. modulus - 1 ) {
-                        for ( output in 0 .. modulus - 1 ){
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  multiplier1 in 0 .. modulus - 1  {
+                    for  multiplier2 in 0 .. modulus - 1  {
+                        for  output in 0 .. modulus - 1  {
                             ModularMultiplierMontgomeryFormTestHelper(
                                 ModularMultiplier, 
                                 IntAsBigInt(multiplier1), 
@@ -1918,7 +1918,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[3 * nQubits + nAncillas]){
+            use register = Qubit[3 * nQubits + nAncillas] {
                 mutable actual1 = 0L;
                 mutable actual2 = 0L;
                 mutable result  = 0L;
@@ -1963,8 +1963,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set result = MeasureMontgomeryInteger(resultMMI);
                 Fact(result == 0L, $"Uncomputed: Result: Expected {0}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeBigIntInMontgomeryForm(multiplier1, multiplier1MMI);
                         EncodeBigIntInMontgomeryForm(multiplier2, multiplier2MMI);
@@ -2048,9 +2048,9 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nAncillas : Int
     ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( multiplier1 in 0 .. modulus - 1 ) {
-                    for( multiplier2 in 0 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  multiplier1 in 0 .. modulus - 1  {
+                    for  multiplier2 in 0 .. modulus - 1  {
                         ModularMulMontgomeryFormOpenTestHelper(
                             ModularMultiplier, 
                             IntAsBigInt(multiplier1), 
@@ -2072,7 +2072,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nTests : Int
     ) : Unit {
         body (...) {
-            for (idx in 0 .. nTests - 1){
+            for idx in 0 .. nTests - 1 {
                 let modulus = 2L^(nQubits - 1) + 2L*RandomBigInt(2L^(nQubits - 2)) + 1L;
                 let multiplier1 = RandomBigInt(modulus);
                 let multiplier2 = RandomBigInt(modulus);
@@ -2170,7 +2170,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits + nAncillas]){
+            use register = Qubit[2 * nQubits + nAncillas] {
                 mutable actual2 = 0L;
                 mutable result  = 0L;
                 mutable ancilla = 0L;
@@ -2208,8 +2208,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set result = MeasureMontgomeryInteger(resultMMI);
                 Fact(result == 0L, $"Uncomputed: Result: Expected {0}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit register
                         EncodeBigIntInMontgomeryForm(multiplier2, multiplier2MMI);
 
@@ -2281,9 +2281,9 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nAncillas : Int
         ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( multiplier1 in 0 .. modulus - 1 ) {
-                    for( multiplier2 in 0 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  multiplier1 in 0 .. modulus - 1  {
+                    for  multiplier2 in 0 .. modulus - 1  {
                         ModularMulConstantMontgomeryFormOpenTestHelper(
                             ModularMultiplier, 
                             IntAsBigInt(multiplier1), 
@@ -2372,7 +2372,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nQubits : Int ) : Unit {
         body (...) {
             // Bookkeeping and ancilla allocation
-            using (register = Qubit[2 * nQubits]) {
+            use register = Qubit[2 * nQubits] {
                 mutable actual1 = 0L;
                 mutable actual2 = 0L;
                 mutable actualr = 0L;
@@ -2394,8 +2394,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actualr = MeasureMontgomeryInteger(resultMMI);
                 Fact(expected== actualr, $"Expected {expected} as product, got {actualr}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeBigIntInMontgomeryForm(multiplier2, multiplier2MMI);
                         EncodeBigIntInMontgomeryForm(output, resultMMI);
@@ -2437,10 +2437,10 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nQubits : Int 
     ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( multiplier1 in 0 .. modulus - 1 ) {
-                    for( multiplier2 in 0 .. modulus - 1 ) {
-                        for ( output in 0 .. modulus - 1 ){
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  multiplier1 in 0 .. modulus - 1  {
+                    for  multiplier2 in 0 .. modulus - 1  {
+                        for  output in 0 .. modulus - 1  {
                             ModularConstantMultiplierMontgomeryFormTestHelper(
                                 ModularMultiplier, 
                                 IntAsBigInt(multiplier1), 
@@ -2527,7 +2527,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and ancilla allocation
-            using (register = Qubit[2 * nQubits]) {
+            use register = Qubit[2 * nQubits] {
                 mutable actual = 0L;
                 mutable actualr = 0L;
 
@@ -2548,8 +2548,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actualr = MeasureMontgomeryInteger(resultMMI);
                 Fact(expected== actualr, $"Inverse: Expected {expected}, got {actualr}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeBigIntInMontgomeryForm(integer, integerMMI);
                         EncodeBigIntInMontgomeryForm(0L, resultMMI);
@@ -2589,8 +2589,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
 
     operation ModularInvMontgomeryFormExhaustiveTestHelper ( ModularInverter : ( (MontModInt, MontModInt) => Unit is Ctl), nQubits : Int ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( integer1 in 0 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  integer1 in 0 .. modulus - 1  {
                     if (GreatestCommonDivisorI(modulus, integer1)==1){
                         ModularInvMontgomeryFormTestHelper(ModularInverter, IntAsBigInt(integer1), IntAsBigInt(modulus), nQubits);
                     }
@@ -2645,7 +2645,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[3 * nQubits]) {
+            use register = Qubit[3 * nQubits] {
                 mutable actuali = 0L;
                 mutable actualm = 0L;
                 mutable actuals = 0L;
@@ -2671,8 +2671,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actuals = MeasureMontgomeryInteger(summandMMI);
                 Fact(sum== actuals, $"Result: Expected {sum}, got {actuals}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeBigIntInMontgomeryForm(invertand, invertandMMI);
                         EncodeBigIntInMontgomeryForm(multiplicand, multiplicandMMI);
@@ -2721,11 +2721,11 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nQubits : Int 
     ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( invertand in 1 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  invertand in 1 .. modulus - 1  {
                     if (GreatestCommonDivisorI(modulus, invertand)==1){
-                        for( multiplicand in 0 .. modulus - 1 ) {
-                            for( summand in 0 .. modulus - 1 ) {
+                        for  multiplicand in 0 .. modulus - 1  {
+                            for  summand in 0 .. modulus - 1  {
                                 ModularDivideMontgomeryFormTestHelper(
                                     ModularDivider, 
                                     IntAsBigInt(modulus), 
@@ -2778,7 +2778,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     operation ModularDivMontgomeryFormLargeTestReversible () : Unit {
         body (...) {
             let nTests = 2;
-            for (nQubits in 6..192){
+            for nQubits in 6..192 {
                 Message($"{nQubits} qubits:");
                 mutable idxTest = 0;
                 while (idxTest <= nTests){
@@ -2822,7 +2822,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits + nAncillas]){
+            use register = Qubit[2 * nQubits + nAncillas] {
                 mutable actual = 0L;
                 mutable result  = 0L;
                 mutable ancilla = 0L;
@@ -2860,8 +2860,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set result = MeasureMontgomeryInteger(resultMMI);
                 Fact(result == 0L, $"Uncomputed: Result: Expected {0}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit register
                         EncodeBigIntInMontgomeryForm(input, inputMMI);
 
@@ -2932,8 +2932,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nAncillas : Int 
     ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( integer in 0 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  integer in 0 .. modulus - 1  {
                     if (GreatestCommonDivisorI(integer, modulus)==1 or integer==0){
                         ModularInvMontgomeryFormOpenTestHelper(ModularInverter, IntAsBigInt(integer), IntAsBigInt(modulus), nQubits, nAncillas);
                     }
@@ -2992,7 +2992,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits]) {
+            use register = Qubit[2 * nQubits] {
                 mutable actual = 0L;
                 mutable actualr = 0L;
 
@@ -3013,8 +3013,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set actualr = MeasureMontgomeryInteger(resultMMI);
                 Fact(expected== actualr, $"Result: Expected {expected}, got {actualr}");
 
-                for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeBigIntInMontgomeryForm(integer, integerMMI);
                         EncodeBigIntInMontgomeryForm(summand, resultMMI); 
@@ -3057,9 +3057,9 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nQubits : Int 
     ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( integer in 0 .. modulus - 1 ) {
-                    for( summand in 0 .. modulus - 1 ){
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  integer in 0 .. modulus - 1  {
+                    for  summand in 0 .. modulus - 1  {
                         ModularSquAndAddMontgomeryFormTestHelper(ModularSquarer, IntAsBigInt(integer), IntAsBigInt(summand), IntAsBigInt(modulus), nQubits);
                     }
                 }
@@ -3114,7 +3114,7 @@ namespace Microsoft.Quantum.Crypto.Tests {
     ) : Unit {
         body (...) {
             // Bookkeeping and qubit allocation
-            using (register = Qubit[2 * nQubits + nAncillas]){
+            use register = Qubit[2 * nQubits + nAncillas] {
                 mutable actual = 0L;
                 mutable result  = 0L;
                 mutable ancilla = 0L;
@@ -3152,8 +3152,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
                 set result = MeasureMontgomeryInteger(resultMMI);
                 Fact(result == 0L, $"Uncomputed: Result: Expected {0}, got {result}");
 
-                 for (numberOfControls in 1..2) { 
-                    using (controls = Qubit[numberOfControls]) {
+                 for numberOfControls in 1..2 { 
+                    use controls = Qubit[numberOfControls] {
                         // Write to qubit registers
                         EncodeBigIntInMontgomeryForm(input, inputMMI);
 
@@ -3225,8 +3225,8 @@ namespace Microsoft.Quantum.Crypto.Tests {
         nAncillas : Int 
     ) : Unit {
         body (...) {
-            for (modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1) {
-                for( integer in 0 .. modulus - 1 ) {
+            for modulus in 2^(nQubits - 1) + 1 ..2.. 2^nQubits - 1 {
+                for  integer in 0 .. modulus - 1  {
                     ModularSquMontgomeryFormOpenTestHelper(ModularSquarer, IntAsBigInt(integer), IntAsBigInt(modulus), nQubits, nAncillas);
                 }
             }

--- a/ResourceEstimator/DepthCounterCSV.cs
+++ b/ResourceEstimator/DepthCounterCSV.cs
@@ -47,24 +47,45 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator.CommaSeparated
         { get; set; }
 
         [FieldConverter(typeof(QDecimalConverter))]
-        public decimal StartTimeAverage
+        public decimal StartTimeDifferenceAverage
         { get; set; }
 
         [FieldConverter(typeof(QDecimalConverter))]
-        public decimal StartTimeSecondMoment
+        public decimal StartTimeDifferenceSecondMoment
         { get; set; }
 
         [FieldConverter(typeof(QDecimalConverter))] // [FieldConverter(ConverterKind.Decimal, ".")]
-        public decimal? StartTimeVariance
+        public decimal? StartTimeDifferenceVariance
         { get; set; }
 
-        public long StartTimeSum
+        public long StartTimeDifferenceSum
         { get; set; }
 
-        public long StartTimeMin
+        public long StartTimeDifferenceMin
         { get; set; }
 
-        public long StartTimeMax
+        public long StartTimeDifferenceMax
+        { get; set; }
+
+         [FieldConverter(typeof(QDecimalConverter))]
+        public decimal WidthAverage
+        { get; set; }
+
+        [FieldConverter(typeof(QDecimalConverter))]
+        public decimal WidthSecondMoment
+        { get; set; }
+
+        [FieldConverter(typeof(QDecimalConverter))]
+        public decimal? WidthVariance
+        { get; set; }
+
+        public long WidthSum
+        { get; set; }
+
+        public long WidthMin
+        { get; set; }
+
+        public long WidthMax
         { get; set; }
     }
 }

--- a/ResourceEstimator/DisplayCSV.cs
+++ b/ResourceEstimator/DisplayCSV.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator.CommaSeparated
                 {
                     if (cust.Name == line_name || all)
                     {
-                        results += $"{cust.DepthAverage}, ";
+                        results += $"{cust.DepthAverage}, {cust.WidthAverage}, {cust.WidthMax}, ";
                     }
                 }
             }

--- a/ResourceEstimator/ResourceEstimateWrappers.qs
+++ b/ResourceEstimator/ResourceEstimateWrappers.qs
@@ -19,14 +19,14 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
 
     operation ClearRegister(register:Qubit[]):Unit {
-        for (idx in 0..Length(register)-1){
+        for idx in 0..Length(register)-1 {
             AssertMeasurementProbability([PauliZ],[register[idx]],Zero,0.0,"n/a",0.5);
         }	
         ResetAll(register);
     }
 
     operation CCNOTEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using (qubits = Qubit[3]){
+        use qubits = Qubit[3] {
             CCNOT(qubits[0], qubits[1], qubits[2]);
             ClearRegister(qubits);
         }
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
     operation ControlledOp<'T>(isControlled : Bool, op : ('T => Unit is Ctl), parameters : 'T) : Unit {
         if (isControlled){
-            using (controls = Qubit[1]){
+            use controls = Qubit[1] {
                 (Controlled op)(controls, (parameters));
                 ClearRegister(controls);
             }
@@ -46,11 +46,11 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     operation QuantumWhileEstimator(nQubits : Int, isControlled : Bool) : Unit {
         //The types are confusing, so this does the control manually
         let logn = BitSizeI(nQubits);
-        using (kQubits = Qubit[logn +1]){
+        use kQubits = Qubit[logn +1] {
             let counter = QubitsAsCounter(kQubits);
             counter::Prepare();
             if (isControlled){
-                using (controls = Qubit[1]){
+                use controls = Qubit[1] {
                     (Controlled QuantumWhile)(controls, (0, nQubits, NoOp<Int>, NoOp<Qubit>, NoOp<Int>, counter));
                     ClearRegister(controls);
                 }
@@ -63,14 +63,14 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
     operation QuantumWhileAdditionEstimator(nQubits : Int, isControlled : Bool) : Unit {
         let logn = BitSizeI(nQubits);
-        using ((kQubits, xQubits, yQubits) = (Qubit[logn +1], Qubit[nQubits], Qubit[nQubits])){
+        use (kQubits, xQubits, yQubits) = (Qubit[logn +1], Qubit[nQubits], Qubit[nQubits]) {
             let counter = QubitsAsCounter(kQubits);
             let xs = LittleEndian(xQubits);
             let ys = LittleEndian(yQubits);
             counter::Prepare();
             let AddWithInteger = DummyIntegerWrapper(AddIntegerNoCarry, (xs,ys), _);
             if (isControlled){
-                using (controls = Qubit[1]){
+                use controls = Qubit[1] {
                     (Controlled QuantumWhile)(controls, (0,nQubits, AddWithInteger, counter::Test, AddWithInteger, counter));
                     ClearRegister(controls);
                 }
@@ -83,8 +83,8 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
     operation LookUpEstimator(nQubits : Int, isControlled : Bool) : Unit {
         if (nQubits < 25){
-            using ((addressQubits, outputQubits) = (Qubit[nQubits], Qubit[nQubits])){
-                let valueTable = Microsoft.Quantum.Arrays.ForEach(RandomBoundedBigInt(_, 2L^nQubits - 1L ), new BigInt[2^nQubits]);
+            use (addressQubits, outputQubits) = (Qubit[nQubits], Qubit[nQubits]) {
+                let valueTable = Microsoft.Quantum.Arrays.ForEach(RandomBoundedBigInt(_, 2L^nQubits - 1L ), [0L, size= 2^nQubits]);
                 let value = LittleEndian(outputQubits);
                 let address = LittleEndian(addressQubits);
                 ControlledOp<(BigInt[], (BigInt => Unit is Ctl + Adj), LittleEndian)>
@@ -95,7 +95,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     }
 
     operation PointLookUpEstimator(nQubits : Int, isControlled : Bool, windowSize : Int) : Unit {
-        using ((addressQubits, outputXs, outputYs) = (Qubit[windowSize + 1], Qubit[nQubits], Qubit[nQubits])){
+        use (addressQubits, outputXs, outputYs) = (Qubit[windowSize + 1], Qubit[nQubits], Qubit[nQubits]) {
             let points  = RandomPointArray(2L^nQubits - 1L, windowSize) + [RandomInvalidECPoint(false, 2L^nQubits - 1L)];
             let value = ECPointMontgomeryForm(
                 MontModInt(2L^nQubits - 1L, LittleEndian(outputXs)),
@@ -109,21 +109,21 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     }
 
     operation CheckIfAllZeroEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using ((xs,result) = (Qubit[nQubits], Qubit())){
+        use (xs,result) = (Qubit[nQubits], Qubit()) {
             ControlledOp(isControlled, CheckIfAllZero, (xs, result));
             ClearRegister(xs+[result]);
         }
     }
 
     operation CheckIfAllOneEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using ((xs,result) = (Qubit[nQubits], Qubit())){
+        use (xs,result) = (Qubit[nQubits], Qubit()) {
             ControlledOp(isControlled, CheckIfAllOnes, (xs, result));
             ClearRegister(xs+[result]);
         }
     }
 
     operation AdditionEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using (register = Qubit[2*nQubits+1]){
+        use register = Qubit[2*nQubits+1] {
             let xs = LittleEndian(register[0..nQubits-1]);
             let ys = LittleEndian(register[nQubits..2*nQubits-1]);
             let carry = register[2*nQubits];
@@ -136,7 +136,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
 
     operation AdditionNoCarryEstimator(nQubits:Int, isControlled : Bool):Unit {
-        using (register = Qubit[2*nQubits]){
+        use register = Qubit[2*nQubits] {
             let xs = LittleEndian(register[0..nQubits-1]);
             let ys = LittleEndian(register[nQubits..2*nQubits-1]);
             ControlledOp(isControlled, AddIntegerNoCarry, (xs,ys));
@@ -146,7 +146,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
 
     operation CyclicShiftEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using (register = Qubit[nQubits]){
+        use register = Qubit[nQubits] {
             let qInteger = LittleEndian(register[0 .. nQubits - 1]);
             ControlledOp(isControlled, CyclicRotateRegister, (qInteger));
             ClearRegister(register);
@@ -154,7 +154,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     }
 
     operation ConstantAdditionEstimator(nQubits:Int, isControlled : Bool):Unit {
-        using (register = Qubit[nQubits]){
+        use register = Qubit[nQubits] {
             let constant = RandomBigInt(2L^nQubits);
             ControlledOp(isControlled, AddConstant, (constant, LittleEndian(register)));
             ClearRegister(register);
@@ -164,7 +164,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
 
     operation GreaterThanEstimator(nQubits:Int, isControlled : Bool):Unit {
-        using (register = Qubit[2*nQubits+1]){
+        use register = Qubit[2*nQubits+1] {
             let xs = LittleEndian(register[0..nQubits-1]);
             let ys = LittleEndian(register[nQubits..2*nQubits-1]);
             let result = register[2*nQubits];
@@ -176,7 +176,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
 
     operation ModularDblEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using (register = Qubit[nQubits]){
+        use register = Qubit[nQubits] {
             let modulus = 2L * RandomBigInt(2L ^ (nQubits - 1)) + 1L;
             let xs = LittleEndian(register);
             ControlledOp(isControlled, ModularDblConstantModulus, (modulus, xs));
@@ -187,7 +187,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     
 
     operation ModularAdditionEstimator(nQubits:Int, isControlled : Bool):Unit {
-        using (register = Qubit[2*nQubits]){
+        use register = Qubit[2*nQubits] {
             let xs = LittleEndian(register[0..nQubits-1]);
             let ys = LittleEndian(register[nQubits..2*nQubits-1]);
             let modulus = RandomBigInt(2L ^ nQubits);
@@ -198,7 +198,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
     operation MontgomeryWindowedMultiplicationWindowTest(nQubits : Int, isControlled : Bool, windowSize : Int) : Unit {
         let (nAncillas, nOutputs) = AncillaCountModularMulMontgomeryForm(nQubits);
-        using ((register, ancillas) = (Qubit[3*nQubits], Qubit[nAncillas])){
+        use (register, ancillas) = (Qubit[3*nQubits], Qubit[nAncillas]) {
             let xs = LittleEndian(register[0..nQubits-1]);
             let ys = LittleEndian(register[nQubits..2*nQubits-1]);
             let zs = LittleEndian(register[2*nQubits..3*nQubits -1]);
@@ -212,7 +212,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     }
 
     operation NonWindowedMontgomeryMultiplicationEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using (register = Qubit[3*nQubits]){
+        use register = Qubit[3*nQubits] {
             let xs = LittleEndian(register[0..nQubits-1]);
             let ys = LittleEndian(register[nQubits..2*nQubits-1]);
             let zs = LittleEndian(register[2*nQubits..3*nQubits -1]);
@@ -221,7 +221,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
             let yMMI= MontModInt(modulus, ys);
             let zMMI= MontModInt(modulus, zs);
             let (nAncillas, nOutputs) = AncillaCountModularMulMontgomeryForm(nQubits);
-            using (ancillas = Qubit[nAncillas]){
+            use ancillas = Qubit[nAncillas] {
                 ControlledOp(isControlled, ModularMulMontgomeryFormGeneric(CopyMontModInt(_,zMMI),_, _), (xMMI, yMMI));
                 ClearRegister(ancillas);
             }
@@ -230,7 +230,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     }
 
     operation MontgomeryMultiplicationEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using (register = Qubit[3*nQubits]){
+        use register = Qubit[3*nQubits] {
             let xs = LittleEndian(register[0..nQubits-1]);
             let ys = LittleEndian(register[nQubits..2*nQubits-1]);
             let zs = LittleEndian(register[2*nQubits..3*nQubits -1]);
@@ -245,7 +245,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     }
 
     operation MontgomerySquareEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using (register = Qubit[2*nQubits]){
+        use register = Qubit[2*nQubits] {
             let xs = LittleEndian(register[0..nQubits-1]);
             let zs = LittleEndian(register[nQubits..2*nQubits -1]);
             let modulus = 2L*RandomBigInt(2L^(nQubits - 1)) + 1L;
@@ -259,7 +259,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
 
     operation MontgomeryInversionRoundEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using ((u,v,r,s,ms,controls)=(Qubit[nQubits], Qubit[nQubits], Qubit[nQubits+1], Qubit[nQubits+1], Qubit[2*nQubits], Qubit[1])){
+        use (u,v,r,s,ms,controls)=(Qubit[nQubits], Qubit[nQubits], Qubit[nQubits+1], Qubit[nQubits+1], Qubit[2*nQubits], Qubit[1]) {
             let us = LittleEndian(u);
             let vs = LittleEndian(v);
             let rs = LittleEndian(r);
@@ -271,7 +271,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
 
     operation MontgomeryInversionEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using (register = Qubit[2*nQubits]){
+        use register = Qubit[2*nQubits] {
             let xs = LittleEndian(register[0..nQubits-1]);
             let ys = LittleEndian(register[nQubits..2*nQubits-1]);
             let modulus = 2L*RandomBigInt(2L^(nQubits - 1)) + 1L;
@@ -284,7 +284,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
     operation ModularDivisionEstimator(nQubits : Int, isControlled : Bool):Unit {
         let modulus = 2L * RandomBigInt(2L ^ (nQubits - 1)) + 1L;
-        using ((xs, ys, zs)=(Qubit[nQubits], Qubit[nQubits], Qubit[nQubits])){
+        use (xs, ys, zs)=(Qubit[nQubits], Qubit[nQubits], Qubit[nQubits]) {
             ControlledOp(isControlled, ModularDivideAndAddMontgomeryForm, 
                 (MontModInt(modulus,LittleEndian(xs)),
                 MontModInt(modulus,LittleEndian(ys)),
@@ -295,7 +295,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     }
 
     operation EllipticCurveConstantPointAdditionEstimator(nQubits : Int, isControlled : Bool) : Unit {
-        using (register = Qubit[2 * nQubits]){
+        use register = Qubit[2 * nQubits] {
             let modulus = 2l*RandomBigInt(2L^(nQubits-1)) - 1L;
             let pointX = RandomBoundedBigInt(0L, modulus);
             let pointY = RandomBoundedBigInt(0L, modulus);
@@ -320,12 +320,12 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
     operation RandomPointArray(modulus : BigInt, windowSize : Int) : ECPointClassical[] {
         return Microsoft.Quantum.Arrays.ForEach(RandomInvalidECPoint(_, modulus),
-            new Bool[2^windowSize]
+            [false, size = 2^windowSize]
         );
     }
 
     operation EllipticCurveWindowedPointAdditionLowWidthWindowTest(nQubits : Int, isControlled : Bool, windowSize : Int) : Unit {
-        using (register = Qubit[2 * nQubits + windowSize]){
+        use register = Qubit[2 * nQubits + windowSize] {
             let modulus = 2L*RandomBoundedBigInt(2L^(nQubits - 2), 2L^(nQubits-1)) + 1L;	
             let points = RandomPointArray(modulus, windowSize);
             let xs = LittleEndian(register[0 .. nQubits - 1]);
@@ -342,7 +342,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
 
     operation EllipticCurveWindowedPointAdditionWindowTest(nQubits : Int, isControlled : Bool, windowSize : Int) : Unit {
-        using (register = Qubit[2 * nQubits + windowSize]){
+        use register = Qubit[2 * nQubits + windowSize] {
             let modulus = 2L*RandomBoundedBigInt(2L^(nQubits - 2), 2L^(nQubits-1)) + 1L;	
             let points = RandomPointArray(modulus, windowSize);
             let xs = LittleEndian(register[0 .. nQubits - 1]);
@@ -358,7 +358,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
     operation EllipticCurveSignedWindowedPointAdditionWindowTest(nQubits : Int, isControlled : Bool, windowSize : Int) : Unit {
         
-        using (register = Qubit[2 * nQubits + windowSize]){
+        use register = Qubit[2 * nQubits + windowSize] {
             let modulus = 2L*RandomBoundedBigInt(2L^(nQubits - 2), 2L^(nQubits-1)) + 1L;
             Message($"OG modulus: {modulus}");	
             let points = RandomPointArray(modulus, windowSize - 1) + [RandomInvalidECPoint(false, modulus)];
@@ -425,7 +425,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
         }
         set modulus = curve::modulus;
         let windowSize = OptimalPointAdditionWindowSize(nQubits);
-        using (register = Qubit[2 * nQubits + windowSize]){	
+        use register = Qubit[2 * nQubits + windowSize] {	
             let points = PointTable(basePoint, 
                 ECPointClassical(0L, 0L, false, modulus),
                 curve,
@@ -448,8 +448,8 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
         let modulus = RandomFp2Modulus(nQubits);
         let pointP = ECPointMontgomeryXZClassical(RandomFp2ElementClassical(modulus), RandomFp2ElementClassical(modulus));
         let (nAncillas, _) = AncillaCountECPointDiffAddition(nQubits);
-        using ((qQubits, qMinPQubits, ancillas, outputQubits) = 
-            (Qubit[4 * nQubits], Qubit[4 * nQubits], Qubit[nAncillas], Qubit[4 * nQubits])){
+        use (qQubits, qMinPQubits, ancillas, outputQubits) = 
+            (Qubit[4 * nQubits], Qubit[4 * nQubits], Qubit[nAncillas], Qubit[4 * nQubits]){
             let pointQ = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, qQubits);
             let pointQminP = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, qMinPQubits);
             let outputPoint = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, outputQubits);
@@ -462,8 +462,8 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     operation PointDoublingEstimator(nQubits : Int, isControlled : Bool) : Unit {
         let modulus = RandomFp2Modulus(nQubits);
         let (nAncillas, _) = AncillaCountDoubleECPoint(nQubits);
-        using ((pointQubits, curveQubits, ancillas, outputQubits)
-            = (Qubit[4 * nQubits], Qubit[4 * nQubits], Qubit[nAncillas], Qubit[4 * nQubits])){
+        use (pointQubits, curveQubits, ancillas, outputQubits)
+            = (Qubit[4 * nQubits], Qubit[4 * nQubits], Qubit[nAncillas], Qubit[4 * nQubits]){
             let point = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, pointQubits);
             let curve = QubitArrayAsECCoordsMontgomeryFormAPlusC(modulus, nQubits, curveQubits);
             let outputPoint = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, outputQubits);
@@ -474,8 +474,8 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
     operation TwoIsogenyPointEstimator(nQubits : Int, isControlled : Bool) : Unit {
         let modulus = RandomFp2Modulus(nQubits);
-        using ((kernelQubits, targetQubits, outputQubits)
-            = (Qubit[4 * nQubits], Qubit[4 * nQubits], Qubit[4 * nQubits])){
+        use (kernelQubits, targetQubits, outputQubits)
+            = (Qubit[4 * nQubits], Qubit[4 * nQubits], Qubit[4 * nQubits]){
             let kernelPoint = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, kernelQubits);
             let targetPoint = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, targetQubits);
             let outputPoint = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, outputQubits);
@@ -485,8 +485,8 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     }
     operation TwoIsogenyCurveEstimator(nQubits : Int, isControlled : Bool) : Unit {
         let modulus = RandomFp2Modulus(nQubits);
-        using ((kernelQubits, outputQubits)
-            = (Qubit[4 * nQubits], Qubit[4 * nQubits])){
+        use (kernelQubits, outputQubits)
+            = (Qubit[4 * nQubits], Qubit[4 * nQubits]){
             let kernelPoint = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, kernelQubits);
             let outputCurve = QubitArrayAsECCoordsMontgomeryFormAPlusC(modulus, nQubits, outputQubits);
             ControlledOp(isControlled, TwoIsogenyOfCurveMontgomeryXZ, (kernelPoint, outputCurve));
@@ -499,8 +499,8 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
         let modulus = sikeParams::prime;
         let pointP = sikeParams::pointP;
         let (nAncillas, _) = AncillaCountECPointDiffAddition(nQubits);
-        using ((qQubits, qMinPQubits, ancillas, outputQubits) = 
-            (Qubit[4 * nQubits], Qubit[4 * nQubits], Qubit[nAncillas], Qubit[4 * nQubits])){
+        use (qQubits, qMinPQubits, ancillas, outputQubits) = 
+            (Qubit[4 * nQubits], Qubit[4 * nQubits], Qubit[nAncillas], Qubit[4 * nQubits]){
             let pointQ = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, qQubits);
             let pointQminP = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, qMinPQubits);
             let outputPoint = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, outputQubits);
@@ -524,8 +524,8 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     operation SIKEPointDoublingEstimator(nQubits : Int, isControlled : Bool) : Unit {
         let modulus = (GetSIKEParamsForQubits(nQubits))::prime;
         let (nAncillas, _) = AncillaCountDoubleECPoint(nQubits);
-        using ((pointQubits, curveQubits, ancillas, outputQubits)
-            = (Qubit[4 * nQubits], Qubit[4 * nQubits], Qubit[nAncillas], Qubit[4 * nQubits])){
+        use (pointQubits, curveQubits, ancillas, outputQubits)
+            = (Qubit[4 * nQubits], Qubit[4 * nQubits], Qubit[nAncillas], Qubit[4 * nQubits]){
             let point = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, pointQubits);
             let curve = QubitArrayAsECCoordsMontgomeryFormAPlusC(modulus, nQubits, curveQubits);
             let outputPoint = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, outputQubits);
@@ -537,8 +537,8 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
 
     operation SIKETwoIsogenyCurveEstimator(nQubits : Int, isControlled : Bool) : Unit {
         let modulus = (GetSIKEParamsForQubits(nQubits))::prime;
-        using ((kernelQubits, outputQubits)
-            = (Qubit[4 * nQubits], Qubit[4 * nQubits])){
+        use (kernelQubits, outputQubits)
+            = (Qubit[4 * nQubits], Qubit[4 * nQubits]){
             let kernelPoint = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, kernelQubits);
             let outputCurve = QubitArrayAsECCoordsMontgomeryFormAPlusC(modulus, nQubits, outputQubits);
             ControlledOp(isControlled, TwoIsogenyOfCurveMontgomeryXZ, (kernelPoint, outputCurve));
@@ -548,8 +548,8 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     
     operation SIKETwoIsogenyPointEstimator(nQubits : Int, isControlled : Bool) : Unit {
         let modulus = (GetSIKEParamsForQubits(nQubits))::prime;
-        using ((kernelQubits, outputQubits)
-            = (Qubit[4 * nQubits], Qubit[4 * nQubits])){
+        use (kernelQubits, outputQubits)
+            = (Qubit[4 * nQubits], Qubit[4 * nQubits]){
             let kernelPoint = QubitArrayAsECPointMontgomeryXZ(modulus, nQubits, kernelQubits);
             let outputCurve = QubitArrayAsECCoordsMontgomeryFormAPlusC(modulus, nQubits, outputQubits);
             ControlledOp(isControlled, TwoIsogenyOfCurveMontgomeryXZ, (kernelPoint, outputCurve));
@@ -560,7 +560,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
     operation SIKEJInvariantEstimator(nQubits : Int, isControlled : Bool) : Unit {
         let modulus = (GetSIKEParamsForQubits(nQubits))::prime;
         let (nAncillas, _) = AncillaCountJInvariantAPlusC(nQubits);
-        using ((curveQubits, ancillas, jInvariantQubits) = (Qubit[4 * nQubits], Qubit[nAncillas], Qubit[2 * nQubits])){
+        use (curveQubits, ancillas, jInvariantQubits) = (Qubit[4 * nQubits], Qubit[nAncillas], Qubit[2 * nQubits]) {
             let curve = QubitArrayAsECCoordsMontgomeryFormAPlusC(modulus, nQubits, curveQubits);
             let jInvariant = QubitArrayAsFp2MontModInt(modulus, jInvariantQubits);
             ControlledOp(isControlled, GetJInvariantAPlusCOpen, (curve, ancillas, jInvariant));
@@ -577,7 +577,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
         let pointQ = ECPointMontgomeryXZClassical(RandomFp2ElementClassical(modulus), RandomFp2ElementClassical(modulus));
         let pointR = ECPointMontgomeryXZClassical(RandomFp2ElementClassical(modulus), RandomFp2ElementClassical(modulus));
         let height = nQubits/2;
-        using ((coefficientQubits, jQubits) = (Qubit[height], Qubit[2 * nQubits])){
+        use (coefficientQubits, jQubits) = (Qubit[height], Qubit[2 * nQubits]) {
             let coefficient = LittleEndian(coefficientQubits);
             let jInvariant = QubitArrayAsFp2MontModInt(modulus, jQubits);
             ControlledOp(isControlled, ComputeSIKETwoIsogeny, (curve, pointP, pointQ, pointR, height, coefficient, jInvariant));
@@ -593,7 +593,7 @@ namespace Microsoft.Quantum.Crypto.ResourceEstimator
             Fp2ElementClassical(modulus, 8L, 0L),
             Fp2ElementClassical(modulus, 4L, 0L)
         );
-        using ((coefficientQubits, jQubits) = (Qubit[height], Qubit[2 * nQubits])){
+        use (coefficientQubits, jQubits) = (Qubit[height], Qubit[2 * nQubits]) {
             let coefficient = LittleEndian(coefficientQubits);
             let jInvariant = QubitArrayAsFp2MontModInt(modulus, jQubits);
             ControlledOp(isControlled, ComputeSIKETwoIsogeny, 

--- a/ResourceEstimator/ResourceEstimator.csproj
+++ b/ResourceEstimator/ResourceEstimator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082513">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.24.208024">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="filehelpers" Version="3.4.1" />
-    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.12.20082513" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.20082513" />
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.24.208024" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.24.208024" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Changes:
- syntax of C# overrides ("IsMinimizeDepthCostMetric", etc.)
- depth counter has slightly different fields
- "using" and "borrowing" replaced with "use" and "borrow"
- parantheses removed from "for", "use", and "borrow"
- new array initialization syntax